### PR TITLE
Add govuk elements, frontend toolkit and template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# generated assets
+static/stylesheets/

--- a/app/assets.js
+++ b/app/assets.js
@@ -1,0 +1,50 @@
+var config = require('./config');
+var fs = require('fs');
+var Promise = require('bluebird');
+var render = Promise.promisify(require('node-sass').render);
+var glob = Promise.promisifyAll(require('glob'));
+var path = require('path');
+var log = require('bole')('assets');
+
+
+exports.compile_sass = function () {
+  config.sass.sources.forEach(function (source) {
+
+    var base_options = {
+      includePaths: source.includePaths,
+      outputStyle: source.outputStyle
+    };
+
+    glob.globAsync(source.file).then(function (files) {
+
+      if (files.length) {
+        try {
+          fs.mkdirSync(source.outFile);
+        } catch (err) {
+        }
+      }
+
+      files.forEach(function (filename) {
+        var options = Object.assign({}, base_options);
+        options.file = filename;
+        options.outFile = path.join(source.outFile, path.basename(filename, '.scss')) + '.css';
+        log.info('compiling', filename, '->', options.outFile);
+
+        render(options).then(write_css(options.outFile));
+      });
+    });
+  });
+}
+
+
+function write_css(filename) {
+
+  return function (result) {
+
+    fs.writeFile(filename, result.css, function (err) {
+      if (err) {
+        throw err;
+      }
+    });
+  };
+}

--- a/app/assets/sass/app.scss
+++ b/app/assets/sass/app.scss
@@ -1,0 +1,7 @@
+// Path to assets for use with the file-url function
+// in the govuk frontend toolkit's url-helpers partial
+$path: "/static/images/";
+
+// Import GOV.UK elements from /govuk-modules/, this will import the frontend toolkit and some base styles.
+// Take a look in /govuk-modules/_govuk-elements.scss to see which files are imported.
+@import 'govuk-elements';

--- a/app/config.js
+++ b/app/config.js
@@ -1,5 +1,8 @@
+var join = require('path').join;
 var config = module.exports;
 var PROD = process.env.ENV === 'prod';
+
+var node_modules = join(__dirname, '../node_modules');
 
 
 config.express = {
@@ -15,6 +18,34 @@ config.apps = [
   'base',
   'users'
 ];
+
+config.sass = {
+  sources: [
+    {
+      file: join(__dirname, 'assets/sass/*.scss'),
+      includePaths: [
+        join(node_modules, 'govuk_frontend_toolkit/stylesheets'),
+        join(node_modules, 'govuk_template_jinja/assets/stylesheets'),
+        join(node_modules, 'govuk-elements-sass/public/sass')
+      ],
+      outputStyle: 'expanded',
+      outFile: join(__dirname, '../static/stylesheets/')
+    }
+  ]
+};
+
+config.static = {
+  paths: {
+    '/static': [
+      join(__dirname, '../static'),
+      join(node_modules, 'govuk_template_jinja/assets'),
+      join(node_modules, 'govuk_frontend_toolkit')
+    ],
+    '/static/images/icons': [
+      join(node_modules, 'govuk_frontend_toolkit/images')
+    ]
+  }
+};
 
 config.api = {
   base_url: process.env.API_URL || 'http://localhost:8000',

--- a/app/index.js
+++ b/app/index.js
@@ -4,6 +4,7 @@ var config = require('./config.js');
 var express = require('express');
 var join = require('path').join;
 var nunjucks = require('nunjucks');
+var assets = require('./assets');
 
 
 bole.output({level: config.log.level, stream: process.stdout});
@@ -11,6 +12,9 @@ bole.output({level: config.log.level, stream: process.stdout});
 var app = express();
 app.set('views', __dirname);
 
+if (process.env.ENV !== 'prod') {
+  assets.compile_sass();
+}
 
 nunjucks.configure(join(__dirname, 'templates'), {
   autoescape: true,
@@ -23,6 +27,8 @@ app.use(routes.router);
 
 app.use(require('./errors'));
 
+
+app.locals.asset_path = '/static/';
 
 app.locals.url_for = function (view_name, args) {
 

--- a/app/routes.js
+++ b/app/routes.js
@@ -28,3 +28,13 @@ function add_route(app_name) {
     return route;
   };
 }
+
+// static routes
+Object.keys(config.static.paths).forEach(function (pattern) {
+  var source_paths = config.static.paths[pattern];
+
+  source_paths.forEach(function (path) {
+
+    exports.router.use(pattern, express.static(path));
+  });
+});

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,7 +1,0 @@
-<!doctype html>
-<head>
-</head>
-<body>
-  {% block content %}
-  {% endblock %}
-</body>

--- a/app/templates/govuk_template.html
+++ b/app/templates/govuk_template.html
@@ -1,0 +1,108 @@
+{% block top_of_page %}{% endblock %}
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="{{ html_lang|default('en') }}"><![endif]-->
+<!--[if gt IE 8]><!--><html lang="{{ html_lang|default('en') }}"><!--<![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block page_title %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+
+    <!--[if gt IE 8]><!--><link href="{{ asset_path }}stylesheets/govuk-template.css?0.22.1" media="screen" rel="stylesheet" /><!--<![endif]-->
+    <!--[if IE 6]><link href="{{ asset_path }}stylesheets/govuk-template-ie6.css?0.22.1" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 7]><link href="{{ asset_path }}stylesheets/govuk-template-ie7.css?0.22.1" media="screen" rel="stylesheet" /><![endif]-->
+    <!--[if IE 8]><link href="{{ asset_path }}stylesheets/govuk-template-ie8.css?0.22.1" media="screen" rel="stylesheet" /><![endif]-->
+    <link href="{{ asset_path }}stylesheets/govuk-template-print.css?0.22.1" media="print" rel="stylesheet" />
+
+    <!--[if IE 8]><link href="{{ asset_path }}stylesheets/fonts-ie8.css?0.22.1" media="all" rel="stylesheet" /><![endif]-->
+    <!--[if gte IE 9]><!--><link href="{{ asset_path }}stylesheets/fonts.css?0.22.1" media="all" rel="stylesheet" /><!--<![endif]-->
+    <!--[if lt IE 9]><script src="{{ asset_path }}javascripts/ie.js?0.22.1"></script><![endif]-->
+
+    <link rel="shortcut icon" href="{{ asset_path }}images/favicon.ico?0.22.1" type="image/x-icon" />
+    
+    <link rel="mask-icon" href="{{ asset_path }}images/gov.uk_logotype_crown.svg?0.22.1" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="{{ asset_path }}images/apple-touch-icon-180x180.png?0.22.1">
+    <link rel="apple-touch-icon" sizes="167x167" href="{{ asset_path }}images/apple-touch-icon-167x167.png?0.22.1">
+    <link rel="apple-touch-icon" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.22.1">
+    <link rel="apple-touch-icon" href="{{ asset_path }}images/apple-touch-icon.png?0.22.1">
+
+    
+    <meta name="theme-color" content="#0b0c0c" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta property="og:image" content="{{ asset_path }}images/opengraph-image.png?0.22.1">
+
+    {% block head %}{% endblock %}
+  </head>
+
+  <body class="{% block body_classes %}{% endblock %}">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    {% block body_start %}{% endblock %}
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink">{{ skip_link_message|default('Skip to main content') }}</a>
+      </div>
+    </div>
+
+    <div id="global-cookie-message">
+      
+        {% block cookie_message %}{% endblock %}
+      
+    </div>
+
+    
+    <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="{{ homepage_url|default('https://www.gov.uk') }}" title="{{ logo_link_title|default('Go to the GOV.UK homepage') }}" id="logo" class="content">
+              <img src="{{ asset_path }}images/gov.uk_logotype_crown_invert_trans.png?0.22.1" width="36" height="32" alt=""> {{ global_header_text|default('GOV.UK') }}
+            </a>
+          </div>
+          {% block inside_header %}{% endblock %}
+        </div>
+        {% block proposition_header %}{% endblock %}
+      </div>
+    </header>
+    
+
+    {% block after_header %}{% endblock %}
+
+    <div id="global-header-bar"></div>
+
+    {% block content %}{% endblock %}
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+        {% block footer_top %}{% endblock %}
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+            {% block footer_support_links %}{% endblock %}
+
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+              
+                {% block licence_message %}<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>{% endblock %}
+              
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">{{ crown_copyright_message|default('&copy; Crown copyright')|safe }}</a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+    <script src="{{ asset_path }}javascripts/govuk-template.js?0.22.1"></script>
+
+    {% block body_end %}{% endblock %}
+
+    
+    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+  </body>
+</html>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,5 +1,9 @@
-{% extends "base.html" %}
+{% extends "layouts/two-column.html" %}
 
-{% block content %}
+{% set page_title = "Home" %}
+
+{% block main_column %}
 <a href="{{ url_for('users.list') }}">Users</a>
 {% endblock %}
+
+{% block right_column %}&nbsp;{% endblock %}

--- a/app/templates/includes/head.html
+++ b/app/templates/includes/head.html
@@ -1,0 +1,2 @@
+<!--[if lte IE 8]><link href="/static/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
+<!--[if gt IE 8]><!--><link href="/static/stylesheets/app.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -1,0 +1,41 @@
+{% set homepage_url = '/' %}
+{% set logo_link_title = 'Return to sign in' %}
+{% extends "govuk_template.html" %}
+
+{% block head %}
+  {% include "includes/head.html" %}
+{% endblock %}
+
+{% block cookie_message %}
+  <p>{{cookieText | safe }}</p>
+{% endblock %}
+
+{% block proposition_header %}
+
+  <div class="header-proposition">
+    <div class="content">
+      <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+      <nav id="proposition-menu">
+        <a href="{{ homeUrl }}" id="proposition-name">
+          {% block service_name %}
+            Analytics Platform Control Panel
+          {% endblock %}
+        </a>
+
+        {% include "includes/proposition-links.html" %}
+
+      </nav>
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block header_class %}
+  with-proposition
+{% endblock %}
+
+{% block body_end %}
+  {% block scripts %}
+    {% block page_scripts %}{% endblock %}
+  {% endblock %}
+{% endblock %}

--- a/app/templates/layouts/two-column.html
+++ b/app/templates/layouts/two-column.html
@@ -1,0 +1,31 @@
+{% extends "layouts/base.html" %}
+
+{% block page_title %}
+  {{ page_title }} | Analytics Platform Control Panel
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+  <div class="grid-row">
+    <div class="column-two-thirds">
+
+      <h1 class="heading-xlarge">
+        {{ page_title }}
+      </h1>
+
+      {% block main_column %}{% endblock %}
+
+    </div>
+
+    <div class="column-one-third">
+
+      <div class="demo clearfix">
+        {% block right_column %}{% endblock %}
+      </div>
+
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,6 +1,6 @@
-{% extends "base.html" %}
+{% extends "layouts/two-column.html" %}
 
-{% block content %}
+{% block main_column %}
 
 <h1>Users</h1>
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Analytics Platform Control Panel frontend",
   "main": "./app/server.js",
   "scripts": {
-    "start": "node ./app/server.js | bistre"
+    "start": "nodemon ./app/server.js | bistre"
   },
   "repository": {
     "type": "git",
@@ -20,12 +20,18 @@
     "bole": "3.0.2",
     "dotenv": "^4.0.0",
     "express": "4.15.4",
+    "glob": "^7.1.2",
+    "govuk-elements-sass": "3.0.1",
+    "govuk_frontend_toolkit": "7.0.0",
+    "govuk_template_jinja": "0.22.1",
+    "node-sass": "^4.5.3",
     "nunjucks": "3.0.1",
     "request": "^2.82.0",
     "request-promise": "^4.2.1",
     "request-promise-core": "^1.1.1"
   },
   "devDependencies": {
-    "bistre": "1.0.1"
+    "bistre": "1.0.1",
+    "nodemon": "^1.11.0"
   }
 }


### PR DESCRIPTION
## What

* Add routes for static asset urls
* Add GOV.UK elements, frontend toolkit and template dependencies
* Add script to compile sass/scss into css
* Update templates to use GOV.UK template, assets and styles

## How to review

1. Checkout the repo
2. Run `npm install` to install dependencies
3. Run `npm start` to start the server
4. Visit http://localhost:3000 and see the home page with GOV.UK styles