### PR TITLE
Automatically create static paths on start

### DIFF
--- a/app/assets.js
+++ b/app/assets.js
@@ -14,17 +14,31 @@ exports.compile_sass = function () {
 
     glob(options.files).then(function (files) {
 
-      fs.mkdirAsync(options.outDir)
-
-        .finally(
-          compile_all(files, options))
-
-        .catch(function (error) {
-          // do nothing
-        });
+      mkdirp(options.outDir).then(compile_all(files, options));
 
     });
   });
+}
+
+
+function mkdirp(dir) {
+
+  return new Promise(function (resolve, reject) {
+
+    fs.mkdirAsync(dir)
+      .then(resolve)
+      .catch(function (error) {
+        if (error.code == 'ENOENT') {
+          mkdirp(path.dirname(dir))
+            .then(function () {
+              mkdirp(dir).then(resolve)
+            })
+            .catch(function (error) { reject(error); });
+        }
+      });
+
+  });
+
 }
 
 


### PR DESCRIPTION
## What

* Added function to create static asset paths (as defined by config), creating their parent directories recursively if they don't exist (like `mkdir -p`) - this avoids an error on first run if the static directory does not exist. Also saves requiring an additional dependency.

## How to review

1. Clone the repo (or delete the `static` directory in an existing clone)
2. `npm start`
3. See that static directories are created