### PR TITLE
Add S3 bucket API client functions

### DIFF
--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -19,6 +19,13 @@ exports.add_user = function (user) {
 };
 
 
+exports.users = {
+  'list': exports.list_users,
+  'get': exports.get_user,
+  'add': exports.add_user
+};
+
+
 exports.list_apps = function () {
   return api_request({endpoint: 'apps'});
 };
@@ -36,6 +43,45 @@ exports.get_app = function (id) {
 
 exports.add_app = function (app) {
   return api_request({method: 'POST', endpoint: 'apps', resource: app});
+};
+
+
+exports.apps = {
+  'list': exports.list_apps,
+  'get': exports.get_app,
+  'add': exports.add_app
+};
+
+
+exports.list_buckets = function () {
+  return api_request({endpoint: 's3buckets'});
+};
+
+
+exports.list_app_buckets = function (app_id) {
+  return api_request({endpoint: 'apps/' + app_id + '/s3buckets'});
+};
+
+
+exports.list_user_buckets = function (user_id) {
+  return api_request({endpoint: 'users/' + user_id + '/s3buckets'});
+};
+
+
+exports.get_bucket = function (id) {
+  return api_request({endpoint: 's3buckets/' + id});
+};
+
+
+exports.add_bucket = function (bucket) {
+  return api_request({method: 'POST', endpoint: 's3buckets', resource: bucket});
+};
+
+
+exports.buckets = {
+  'list': exports.list_buckets,
+  'get': exports.get_bucket,
+  'add': exports.add_bucket
 };
 
 

--- a/test/test-apps.js
+++ b/test/test-apps.js
@@ -3,7 +3,7 @@ require('./conftest.js');
 var assert = require('chai').assert;
 var nock = require('nock');
 
-var api = require('../lib/api-client.js');
+var apps = require('../lib/api-client.js').apps;
 
 
 var mock_api = nock('http://localhost:8000');
@@ -20,7 +20,7 @@ describe('Apps API', function () {
         .get('/apps')
         .reply(200, response);
 
-      assert.eventually.deepEqual(api.list_apps(), response);
+      assert.eventually.deepEqual(apps.list(), response);
     });
 
   });
@@ -34,7 +34,7 @@ describe('Apps API', function () {
         .post('/apps', JSON.stringify({}))
         .reply(400, {'error': 'No app data provided'});
 
-      assert.isRejected(api.add_app({}));
+      assert.isRejected(apps.add({}));
     });
 
     it('throws an error if incomplete app data is provided', function () {
@@ -44,7 +44,7 @@ describe('Apps API', function () {
         .post('/apps', JSON.stringify(incomplete_app_data))
         .reply(400, {'error': 'Incomplete app data provided'});
 
-      assert.isRejected(api.add_app(incomplete_app_data));
+      assert.isRejected(apps.add(incomplete_app_data));
     });
 
     it('returns a app id after creating the app', function () {
@@ -69,7 +69,7 @@ describe('Apps API', function () {
         .post('/apps', JSON.stringify(test_app))
         .reply(201, response);
 
-      assert.eventually.propertyVal(api.add_app(test_app), 'id', 1);
+      assert.eventually.propertyVal(apps.add(test_app), 'id', 1);
 
     });
 

--- a/test/test-buckets-response.js
+++ b/test/test-buckets-response.js
@@ -1,0 +1,35 @@
+module.exports = {
+    "count": 3,
+    "next": null,
+    "previous": null,
+    "results": [
+        {
+            "id": 1,
+            "url": "http://cpanelapi-api.services.dev.mojanalytics.xyz/s3buckets/1/",
+            "name": "dev-aldo-cpanel-bucket",
+            "arn": "arn:aws:s3:::dev-aldo-cpanel-bucket",
+            "apps3buckets": [
+                2
+            ],
+            "created_by": null
+        },
+        {
+            "id": 2,
+            "url": "http://cpanelapi-api.services.dev.mojanalytics.xyz/s3buckets/2/",
+            "name": "dev-aldo-test-20170927-1505",
+            "arn": "arn:aws:s3:::dev-aldo-test-20170927-1505",
+            "apps3buckets": [],
+            "created_by": null
+        },
+        {
+            "id": 3,
+            "url": "http://cpanelapi-api.services.dev.mojanalytics.xyz/s3buckets/3/",
+            "name": "dev-secure-geezer",
+            "arn": "arn:aws:s3:::dev-secure-geezer",
+            "apps3buckets": [
+                3
+            ],
+            "created_by": null
+        }
+    ]
+};

--- a/test/test-buckets.js
+++ b/test/test-buckets.js
@@ -1,0 +1,83 @@
+"use strict";
+require('./conftest.js');
+var assert = require('chai').assert;
+var nock = require('nock');
+
+var buckets = require('../lib/api-client.js').buckets;
+
+
+var mock_api = nock('http://localhost:8000');
+
+
+describe('buckets API', function () {
+
+  describe('list()', function () {
+
+    it('returns a list of buckets', function () {
+      var response = require('./test-buckets-response');
+
+      mock_api
+        .get('/s3buckets')
+        .reply(200, response);
+
+      assert.eventually.deepEqual(buckets.list(), response);
+    });
+
+  });
+
+
+  describe('add()', function () {
+
+    it('throws an error if no bucket data is provided', function () {
+      var error = {
+        'name': ['This field is required.'],
+        'apps3buckets': ['This field is required.']
+      };
+
+      mock_api
+        .post('/s3buckets', JSON.stringify({}))
+        .reply(400, error);
+
+      assert.isRejected(buckets.add({}), error);
+    });
+
+    it('throws an error if incomplete bucket data is provided', function () {
+      var incomplete_bucket_data = {'name': 'Test bucket'};
+      var error = {
+        'apps3buckets': ['This field is required.']
+      };
+
+      mock_api
+        .post('/s3buckets', JSON.stringify(incomplete_bucket_data))
+        .reply(400, error);
+
+      assert.isRejected(buckets.add(incomplete_bucket_data), error);
+    });
+
+    it('returns a bucket id after creating the bucket', function () {
+
+      var test_bucket = {
+        'name': 'Test bucket',
+        'apps3buckets': []
+      };
+
+      var current_user_id = null;
+
+      var response ={
+        'id': 1,
+        'name': test_bucket.name,
+        'apps3buckets': [],
+        'created_by': current_user_id
+      };
+
+      mock_api
+        .post('/s3buckets', JSON.stringify(test_bucket))
+        .reply(201, response);
+
+      assert.eventually.propertyVal(buckets.add(test_bucket), 'id', 1);
+
+    });
+
+  });
+
+});

--- a/test/test-users.js
+++ b/test/test-users.js
@@ -3,7 +3,7 @@ require('./conftest.js');
 var assert = require('chai').assert;
 var nock = require('nock');
 
-var api = require('../lib/api-client.js');
+var users = require('../lib/api-client.js').users;
 
 
 var mock_api = nock('http://localhost:8000');
@@ -20,7 +20,7 @@ describe('Users API', function () {
         .get('/users')
         .reply(200, response);
 
-      assert.eventually.deepEqual(api.list_users(), response);
+      assert.eventually.deepEqual(users.list(), response);
     });
 
   });
@@ -34,7 +34,7 @@ describe('Users API', function () {
         .post('/users', JSON.stringify({}))
         .reply(400, {'error': 'No user data provided'});
 
-      assert.isRejected(api.add_user({}));
+      assert.isRejected(users.add({}));
     });
 
     it('throws an error if incomplete user data is provided', function () {
@@ -44,7 +44,7 @@ describe('Users API', function () {
         .post('/users', JSON.stringify(incomplete_user_data))
         .reply(400, {'error': 'Incomplete user data provided'});
 
-      assert.isRejected(api.add_user(incomplete_user_data));
+      assert.isRejected(users.add(incomplete_user_data));
     });
 
     it('returns a user id after creating the user', function () {
@@ -66,7 +66,7 @@ describe('Users API', function () {
         .post('/users', JSON.stringify(test_user))
         .reply(201, response);
 
-      assert.eventually.propertyVal(api.add_user(test_user), 'id', 1);
+      assert.eventually.propertyVal(users.add(test_user), 'id', 1);
 
     });
 


### PR DESCRIPTION
## What

* Added API functions `list_buckets`, `get_bucket` and `add_bucket`
* Added tests for these functions
* Added API function groups, `apps`, `buckets`, and `users`, which enables code like:
```js
var apps = require('lib/api-client').apps;

var app = apps.get(app_id);
```