### PR TITLE
Run with nodemon unless NODE_RESTART=0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Analytics Platform Control Panel frontend",
   "main": "./app/server.js",
   "scripts": {
-    "start": "$([ $NODE_RESTART ] && echo nodemon || echo node) ./app/server.js | bistre",
+    "start": "$([ $NODE_RESTART == 0 ] && echo node || echo nodemon ) ./app/server.js | bistre",
     "test": "mocha -C -R list --recursive --use_strict",
     "collect-static": "node ./bin/collect-static.js | bistre"
   },


### PR DESCRIPTION
## What

* Change logic for `npm start` to use `nodemon` by default and `node` only if `NODE_RESTART` environment variable is set to `0`

## How to review

1. `export NODE_RESTART=0`
2. `npm start`
3. See nodemon restart the app if watched files change
4. Stop the app
5. `export NODE_RESTART=`
6. `npm start`
7. See app start without nodemon