### PR TITLE
Use Auth0 ID token JWT to authenticate with API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN npm run-script collect-static
 ADD static static/
 
 ENV EXPRESS_HOST "0.0.0.0"
+ENV NODE_RESTART "0"
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,19 @@
-FROM node:8.5.0-alpine
+FROM node:6.11.4-alpine
 
 MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
-WORKDIR /home/control-panel
+WORKDIR /home/cpanel
 
 ADD app app/
+ADD bin bin/
 ADD package.json package.json
 ADD lib lib/
-ADD static static/
 
 RUN npm install
-
 ADD node_modules node_modules/
+
+RUN npm run-script collect-static
+ADD static static/
 
 ENV EXPRESS_HOST "0.0.0.0"
 

--- a/app/base/views.js
+++ b/app/base/views.js
@@ -1,11 +1,22 @@
+var api = require('../../lib/api-client');
 var passport = require('passport');
 
 
 exports.home = function (req, res) {
-  res.render('home.html', {
-    env: process.env,
-    session: req.session
-  });
+
+  function render(context) {
+    res.render('home.html', context);
+  }
+
+  if (req.user) {
+    api.authenticate(req.user.id_token);
+    api.users.get(req.user.sub)
+      .then(function (user) { render({'user': user}); })
+      .catch(function (error) { render({'error': error}); });
+
+  } else {
+    render({'user': {}});
+  }
 };
 
 exports.auth_callback = [

--- a/app/index.js
+++ b/app/index.js
@@ -32,9 +32,11 @@ passport.use(new Strategy({
     domain: process.env.AUTH0_DOMAIN,
     clientID: process.env.AUTH0_CLIENT_ID,
     clientSecret: process.env.AUTH0_CLIENT_SECRET,
-    callbackURL: process.env.AUTH0_CALLBACK_URL
+    callbackURL: process.env.AUTH0_CALLBACK_URL,
+    passReqToCallback: true
   },
-  function (issuer, audience, profile, cb) {
+  function (req, issuer, audience, profile, accessToken, refreshToken, params, cb) {
+    profile._json.id_token = params.id_token;
     return cb(null, profile._json);
   }
 ));
@@ -49,6 +51,13 @@ passport.deserializeUser(function(obj, done) {
 
 app.use(passport.initialize());
 app.use(passport.session());
+
+app.use(function (req, res, next) {
+  app.locals.req = req;
+  app.locals.current_user = req.user || null;
+  app.locals.env = process.env;
+  next();
+});
 
 var routes = require('./routes');
 app.use(routes.router);

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,19 +1,19 @@
 {% extends "layouts/base.html" %}
 
-{% set page_title = "Hello " + session.passport.user.name if session.passport.user else "Sign in" %}
+{% set page_title = "Hello " + req.user.name if req.user else "Sign in" %}
 
 {% block content %}
 
 <main id="content" role="main">
-  <!-- <a href="{{ url_for('apps.list') }}">Apps</a>
-  <a href="{{ url_for('users.list') }}">Users</a> -->
 
-  <!-- <p>user.id: {{ user.id }}</p> -->
-  {% if session.passport.user %}
+  {% if req.user %}
   <a href="{{ url_for('base.home') }}" class="button button-secondary">Dashboard</a>
-  {% for key, value in session.passport.user %}
-  <p>{{ key }}: {{ value }}</p>
-  {% endfor %}
+  {% if error %}
+    <p>{{ error }}</p>
+  {% else %}
+    {{ user | dump | safe }}
+  {% endif %}
+
   {% else %}
 
   <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"></div>

--- a/lib/api-client.js
+++ b/lib/api-client.js
@@ -4,114 +4,123 @@ var request = require('request-promise');
 var url = require('url');
 
 
-exports.list_users = function () {
-  return api_request({endpoint: 'users'});
-};
+module.exports = (function () {
+
+  var token = null;
+
+  function api_request(options) {
+    var response_promise = request(override_defaults(options));
+    response_promise.catch(function (error) {
+      log.error(error.name, error.message);
+    });
+    return response_promise;
+  }
 
 
-exports.get_user = function (id) {
-  return api_request({endpoint: 'users/' + id});
-};
+  function override_defaults(options) {
+
+    var defaults = {
+      method: 'GET',
+      uri: endpoint_url(options.endpoint),
+      headers: {
+        'Authorization': jwt_auth(),
+      },
+      body: options.resource,
+      json: true
+    };
+
+    return Object.assign(defaults, options);
+  }
 
 
-exports.add_user = function (user) {
-  return api_request({method: 'POST', endpoint: 'users', resource: user});
-};
+  function endpoint_url(endpoint) {
+    return url.resolve(config.api.base_url, '/' + (endpoint || ''));
+  }
 
 
-exports.users = {
-  'list': exports.list_users,
-  'get': exports.get_user,
-  'add': exports.add_user
-};
+  function basic_auth() {
+    return 'Basic ' + new Buffer(
+      config.api.username + ':' + config.api.password).toString('base64');
+  }
 
 
-exports.list_apps = function () {
-  return api_request({endpoint: 'apps'});
-};
+  function jwt_auth() {
+    return 'JWT ' + token;
+  }
 
 
-exports.list_user_apps = function (user_id) {
-  return api_request({endpoint: 'users/' + user_id + '/apps'});
-};
+  var api = {};
 
-
-exports.get_app = function (id) {
-  return api_request({endpoint: 'apps/' + id});
-};
-
-
-exports.add_app = function (app) {
-  return api_request({method: 'POST', endpoint: 'apps', resource: app});
-};
-
-
-exports.apps = {
-  'list': exports.list_apps,
-  'get': exports.get_app,
-  'add': exports.add_app
-};
-
-
-exports.list_buckets = function () {
-  return api_request({endpoint: 's3buckets'});
-};
-
-
-exports.list_app_buckets = function (app_id) {
-  return api_request({endpoint: 'apps/' + app_id + '/s3buckets'});
-};
-
-
-exports.list_user_buckets = function (user_id) {
-  return api_request({endpoint: 'users/' + user_id + '/s3buckets'});
-};
-
-
-exports.get_bucket = function (id) {
-  return api_request({endpoint: 's3buckets/' + id});
-};
-
-
-exports.add_bucket = function (bucket) {
-  return api_request({method: 'POST', endpoint: 's3buckets', resource: bucket});
-};
-
-
-exports.buckets = {
-  'list': exports.list_buckets,
-  'get': exports.get_bucket,
-  'add': exports.add_bucket
-};
-
-
-function api_request(options) {
-  return request(override_defaults(options));
-}
-
-
-function override_defaults(options) {
-
-  var defaults = {
-    method: 'GET',
-    uri: endpoint_url(options.endpoint),
-    headers: {
-      'Authorization': basic_auth(),
-    },
-    body: options.resource,
-    json: true
+  api.authenticate = function (jwt) {
+    token = jwt;
   };
 
-  return Object.assign(defaults, options);
-}
+  api.list_users = function () {
+    return api_request({endpoint: 'users'});
+  };
 
+  api.get_user = function (id) {
+    return api_request({endpoint: 'users/' + id});
+  };
 
-function endpoint_url(endpoint) {
-  return url.resolve(config.api.base_url, '/' + (endpoint || ''));
-}
+  api.add_user = function (user) {
+    return api_request({method: 'POST', endpoint: 'users', resource: user});
+  };
 
+  api.users = {
+    list: api.list_users,
+    get: api.get_user,
+    add: api.add_user
+  };
 
-function basic_auth() {
-  return 'Basic ' + new Buffer(
-    config.api.username + ':' + config.api.password).toString('base64');
-}
+  api.list_apps = function () {
+      return api_request({endpoint: 'apps'});
+  };
+
+  api.list_user_apps = function (user_id) {
+    return api_request({endpoint: 'users/' + user_id + '/apps'});
+  };
+
+  api.get_app = function (id) {
+    return api_request({endpoint: 'apps/' + id});
+  };
+
+  api.add_app = function (app) {
+    return api_request({method: 'POST', endpoint: 'apps', resource: app});
+  };
+
+  api.apps = {
+    list: api.list_apps,
+    get: api.get_app,
+    add: api.add_app
+  };
+
+  api.list_buckets = function () {
+    return api_request({endpoint: 's3buckets'});
+  };
+
+  api.list_app_buckets = function (app_id) {
+    return api_request({endpoint: 'apps/' + app_id + '/s3buckets'});
+  };
+
+  api.list_user_buckets = function (user_id) {
+    return api_request({endpoint: 'users/' + user_id + '/s3buckets'});
+  };
+
+  api.get_bucket = function (id) {
+    return api_request({endpoint: 's3buckets/' + id});
+  };
+
+  api.add_bucket = function (bucket) {
+    return api_request({method: 'POST', endpoint: 's3buckets', resource: bucket});
+  };
+
+  api.buckets = {
+    'list': api.list_buckets,
+    'get': api.get_bucket,
+    'add': api.add_bucket
+  };
+
+  return api;
+
+})();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Analytics Platform Control Panel frontend",
   "main": "./app/server.js",
   "scripts": {
-    "start": "$([ $NODE_RESTART == 0 ] && echo node || echo nodemon ) ./app/server.js | bistre",
+    "start": "$([ \"x$NODE_RESTART\" == \"x0\" ] && echo node || echo nodemon ) ./app/server.js | bistre",
     "test": "mocha -C -R list --recursive --use_strict",
     "collect-static": "node ./bin/collect-static.js | bistre"
   },


### PR DESCRIPTION
## What

* Update api-client to authenticate with `JWT <token>` authorization header
* Added some template globals to make it more convenient to access current user, request and others

## How to review

1. Run the [control panel API](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/42)
2. Ensure you have the correct values in `.env`:

| name | value |
| ---- | ----- |
| `AUTH0_DOMAIN` | The `Domain` value from the dev `API client` in Auth0 |
| `AUTH0_CLIENT_ID` | The `Client ID` value |
| `AUTH0_CLIENT_SECRET` | The `Client Secret` value |
| `AUTH0_CALLBACK_URL` | `http://localhost:3000/callback` |

3. `npm start`
4. Login with Auth0
5. See user data retrieved from the API