### PR TITLE
Add docker-compose for running locally

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  frontend:
+    build: .
+    image: frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+    links:
+      - api
+    env_file:
+      - .env
+    environment:
+      AUTH0_CALLBACK_URL: "http://localhost:3000/callback"
+      EXPRESS_HOST: "0.0.0.0"
+      API_URL: "http://api:8000"
+  api:
+    image: "quay.io/mojanalytics/control-panel:api"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    links:
+      - db
+    env_file:
+      - .env
+    environment:
+      ALLOWED_HOSTS: "*"
+      DB_HOST: "db"
+      DB_NAME: "controlpanel"
+      DB_USER: "controlpanel"
+      DEBUG: "True"
+      DJANGO_SETTINGS_MODULE: "control_panel_api.settings"
+  db:
+    image: "circleci/postgres:9.6.2"
+    environment:
+      POSTGRES_USER: "controlpanel"
+      POSTGRES_DB: "controlpanel"


### PR DESCRIPTION
## What

* Add a docker-compose file to enable running the frontend, api and database in one (two) command

## How to review

1. Run `docker-compose up`
2. Run `docker-compose exec api python3 manage.py createsuperuser`
3. Browse to http://localhost:3000
