### PR TITLE
Fix login / home templates

### DIFF
--- a/app/base/views.js
+++ b/app/base/views.js
@@ -15,7 +15,7 @@ exports.home = function (req, res) {
       .catch(function (error) { render({'error': error}); });
 
   } else {
-    render({'user': {}});
+    res.redirect('/login');
   }
 };
 

--- a/app/base/views.js
+++ b/app/base/views.js
@@ -1,23 +1,22 @@
 var api = require('../../lib/api-client');
 var passport = require('passport');
+var ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
 
 
-exports.home = function (req, res) {
+exports.home = [
+  ensureLoggedIn('/login'),
+  function (req, res) {
+    function render(context) {
+      res.render('home.html', context);
+    }
 
-  function render(context) {
-    res.render('home.html', context);
-  }
-
-  if (req.user) {
     api.authenticate(req.user.id_token);
     api.users.get(req.user.sub)
       .then(function (user) { render({'user': user}); })
       .catch(function (error) { render({'error': error}); });
-
-  } else {
-    res.redirect('/login');
   }
-};
+];
+
 
 exports.auth_callback = [
   passport.authenticate('auth0-oidc'),

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,25 +1,14 @@
-{% extends "layouts/base.html" %}
+{% extends "layouts/one-column.html" %}
 
-{% set page_title = "Hello " + req.user.name if req.user else "Sign in" %}
+{% set page_title = "Hello " + ( user.name if user.name ) %}
 
-{% block content %}
+{% block main_column %}
 
-<main id="content" role="main">
-
-  {% if req.user %}
   <a href="{{ url_for('base.home') }}" class="button button-secondary">Dashboard</a>
   {% if error %}
     <p>{{ error }}</p>
   {% else %}
     {{ user | dump | safe }}
   {% endif %}
-
-  {% else %}
-
-  <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"></div>
-
-  {% endif %}
-
-</main>
 
 {% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -1,6 +1,6 @@
 {% extends "layouts/one-column.html" %}
 
-{% set page_title = "Hello " + ( user.name if user.name ) %}
+{% set page_title = "Hello " + ( current_user.name if current_user ) %}
 
 {% block main_column %}
 
@@ -8,7 +8,7 @@
   {% if error %}
     <p>{{ error }}</p>
   {% else %}
-    {{ user | dump | safe }}
+    <p>{{ current_user | dump | safe }}</p>
   {% endif %}
 
 {% endblock %}

--- a/app/templates/includes/proposition-links.html
+++ b/app/templates/includes/proposition-links.html
@@ -1,6 +1,6 @@
-{% if session.passport.user %}
+{% if req.user %}
 <ul id="proposition-links">
-  <li><a href="{{ url_for('base.home') }}">Signed in as {{ session.passport.user.name }}</a></li>
+  <li><a href="{{ url_for('base.home') }}">Signed in as {{ user.name if user.name else user.email }}</a></li>
   <li><a href="{{ url_for('base.logout') }}">Sign out</a></li>
 </ul>
 {% endif %}

--- a/app/templates/includes/proposition-links.html
+++ b/app/templates/includes/proposition-links.html
@@ -1,6 +1,6 @@
-{% if req.user %}
+{% if current_user %}
 <ul id="proposition-links">
-  <li><a href="{{ url_for('base.home') }}">Signed in as {{ user.name if user.name else user.email }}</a></li>
+  <li><a href="{{ url_for('base.home') }}">Signed in as {{ current_user.name if current_user.name else current_user.email }}</a></li>
   <li><a href="{{ url_for('base.logout') }}">Sign out</a></li>
 </ul>
 {% endif %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,7 +1,5 @@
 {% extends "layouts/base.html" %}
 
-{% set page_title = "Hello " + user.name if user.name else "Sign in" %}
-
 {% block content %}
 
   <main id="content" role="main">

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,13 @@
+{% extends "layouts/base.html" %}
+
+{% set page_title = "Hello " + user.name if user.name else "Sign in" %}
+
+{% block content %}
+
+  <main id="content" role="main">
+
+    <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"></div>
+
+  </main>
+
+{% endblock %}


### PR DESCRIPTION
## What

We had login and "home" on the same template which were being context switched. This kicks a non-logged-in user to `/login` and then returns them to `/` when they authenticate.

## How to review

1. check out branch and visit root of site
2. observe that you are redirected to `/login`
3. log in with Auth0
4. observe that you now arrive at `/` and your user is dumped to page
