### PR TITLE
Create app template

### DIFF
--- a/app/apps/routes.js
+++ b/app/apps/routes.js
@@ -3,6 +3,7 @@ var views = require('./views');
 
 module.exports = [
 
+  {name: 'new', pattern: '/apps/new', view: views.new_app},
   {name: 'list', pattern: '/apps', view: views.list_apps},
   {name: 'list_user_apps', pattern: '/user/:id/apps', view: views.list_user_apps},
   {name: 'details', pattern: '/apps/:id', view: views.app_details}

--- a/app/apps/views.js
+++ b/app/apps/views.js
@@ -9,7 +9,7 @@ exports.new_app = [
   function (req, res) {
 
     res.render('apps/new.html', {
-      prefix: 'dev-',
+      prefix: process.env.ENV + '-',
       buckets: [
         {
           id: 1,

--- a/app/apps/views.js
+++ b/app/apps/views.js
@@ -2,6 +2,43 @@ var api = require('../api-client');
 var ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
 
 
+exports.new_app = [
+
+  ensureLoggedIn('/login'),
+
+  function (req, res) {
+
+    res.render('apps/new.html', {
+      prefix: 'dev-',
+      buckets: [
+        {
+          id: 1,
+          name: 'dev-dummy-bucket1'
+        },
+        {
+          id: 2,
+          name: 'dev-dummy-bucket2'
+        },
+        {
+          id: 3,
+          name: 'dev-dummy-bucket3'
+        },
+        {
+          id: 4,
+          name: 'dev-dummy-bucket4'
+        },
+        {
+          id: 5,
+          name: 'dev-dummy-bucket5'
+        },
+      ]
+    });
+
+  }
+
+];
+
+
 exports.list_apps = [
   ensureLoggedIn('/'),
   function (req, res, next) {

--- a/app/assets/javascripts/modules/bucket-name.js
+++ b/app/assets/javascripts/modules/bucket-name.js
@@ -1,0 +1,35 @@
+'use strict';
+
+moj.Modules.bucketName = {
+  inputName: 'new-datasource-name',
+
+  init: function() {
+    var self = this;
+
+    if ($('#' + self.inputName).length) {
+      self.bindEvents();
+    }
+  },
+
+  bindEvents: function() {
+    var self = this,
+      $input = $('#' + self.inputName),
+      prefix = $input.data('prefix');
+
+    $input.on('keypress blur', function() {
+      self.checkValue($input, prefix);
+    });
+  },
+
+  checkValue: function($input, prefix) {
+    var val = $input.val();
+
+    if (val.length < prefix.length) {
+      val = prefix;
+    }
+
+    val = val.toLowerCase().replace(/ /gi, '-');
+
+    $input.val(val);
+  }
+};

--- a/app/assets/javascripts/modules/bucket-name.js
+++ b/app/assets/javascripts/modules/bucket-name.js
@@ -5,31 +5,31 @@ moj.Modules.bucketName = {
 
   init: function() {
     var self = this;
+    self.$input = $('#' + self.inputName);
 
-    if ($('#' + self.inputName).length) {
+    if (self.$input.length) {
+      self.prefix = self.$input.data('prefix');
       self.bindEvents();
     }
   },
 
   bindEvents: function() {
-    var self = this,
-      $input = $('#' + self.inputName),
-      prefix = $input.data('prefix');
+    var self = this;
 
-    $input.on('keypress blur', function() {
-      self.checkValue($input, prefix);
+    self.$input.on('keypress blur', function() {
+      self.formatBucketName();
     });
   },
 
-  checkValue: function($input, prefix) {
-    var val = $input.val();
+  formatBucketName: function() {
+    var self = this,
+      val = self.$input.val();
 
-    if (val.length < prefix.length) {
-      val = prefix;
+    if (val.length < self.prefix.length) {
+      val = self.prefix;
     }
 
     val = val.toLowerCase().replace(/ /gi, '-');
-
-    $input.val(val);
+    self.$input.val(val);
   }
 };

--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -1,0 +1,77 @@
+{% extends "layouts/one-column.html" %}
+
+{% set page_title = "Create new app" %}
+
+{% block main_column %}
+
+<form action="/apps/create" method="post">
+
+  <div class="form-group">
+    <label for="name" class="form-label">Name</label>
+    <input class="form-control" type="text" id="name" name="name">
+  </div>
+
+  <div class="form-group">
+    <label for="description" class="form-label">
+      Description
+      <span class="form-hint">Optional</span>
+    </label>
+    <textarea class="form-control" name="description" id="description" cols="30" rows="10"></textarea>
+  </div>
+
+  <div class="form-group">
+    <label for="repoUrl" class="form-label">
+      Github repo url
+      <span class="form-hint">e.g. https://github.com/something-org/lorem-fantastic-app</span>
+    </label>
+    <input class="form-control" type="text" id="repoUrl" name="repoUrl">
+  </div>
+
+  <div class="form-group">
+
+    <fieldset>
+      <h2 class="heading-medium">Attach a datasource (S3 bucket)</h2>
+      <p>Attach an existing bucket to your app, or create a new bucket. This can also be done later.</p>
+      <p>Additional buckets can also be attached after your app is created.</p>
+      <div class="multiple-choice" data-target="new-app-datasource-create-new-source">
+        <input type="radio" id="new-app-datasource-create" name="new-app-datasource" value="create">
+        <label for="new-app-datasource-create">Create a new datasource</label>
+      </div>
+      <div class="panel panel-border-narrow js-hidden" id="new-app-datasource-create-new-source">
+        <p>This can be populated with data later.</p>
+        <label class="form-label" for="new-datasource-name">
+          App data source (bucket) name
+          <span class="form-hint">60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "{{ prefix }}"</span>
+        </label>
+        <input class="form-control" name="new-datasource-name" type="text" id="new-datasource-name" value="{{ prefix }}" data-prefix="{{ prefix }}" pattern="[a-z0-9.-]{1,60}" maxlength="60">
+      </div>
+
+      <div class="multiple-choice" data-target="new-app-datasource-existing-source">
+        <input type="radio" id="new-app-datasource-select" name="new-app-datasource" value="select">
+        <label for="new-app-datasource-select">Attach an existing app data source</label>
+      </div>
+      <div class="panel panel-border-narrow js-hidden" id="new-app-datasource-existing-source">
+        <label class="form-label" for="select-existing-datasource">Select app data source</label>
+        <select name="select-existing-datasource" id="select-existing-datasource" class="form-control">
+          <option value="">Select</option>
+          {% for bucket in buckets %}
+            <option value="{{ bucket.id }}">{{ bucket.name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <div class="multiple-choice">
+        <input type="radio" id="new-app-datasource-later" name="new-app-datasource" value="later">
+        <label for="new-app-datasource-later">Do this later</label>
+      </div>
+    </fieldset>
+
+  </div>
+
+  <div class="form-group">
+    <input type="submit" class="button button-secondary" value="Create">
+  </div>
+
+</form>
+
+{% endblock %}

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -8,7 +8,8 @@
   {% if error %}
     <p>{{ error }}</p>
   {% else %}
-    <p>{{ current_user | dump | safe }}</p>
+    <p><a href="{{ url_for('apps.new') }}" class="button button-secondary">Create new app</a></p>
+    {{ current_user | dump | safe }}
   {% endif %}
 
 {% endblock %}

--- a/app/templates/includes/scripts.html
+++ b/app/templates/includes/scripts.html
@@ -1,10 +1,13 @@
 <!-- Javascript -->
 <script src="/static/jquery.min.js"></script>
-<!-- <script src="/static/javascripts/govuk/show-hide-content.js"></script> -->
+<script src="/static/javascripts/govuk/show-hide-content.js"></script>
 <script src="https://cdn.auth0.com/js/lock-9.min.js"></script>
 
 <script src="/static/javascripts/app.js"></script>
 <!-- initialise -->
 <script type="text/javascript">
+  var showHideContent = new GOVUK.ShowHideContent();
+  showHideContent.init();
+
   window.moj.init();
 </script>


### PR DESCRIPTION
## What

New app template. Form elements are named as they were in the prototype, and may want changing to something that works better for the real thing.

Passed into the view at the moment are the bucket name prefix, which JS prevents the user from removing when creating a new bucket, and an array of dummy buckets for the user to select if they want to attach an existing bucket. The former should probably be governed from somewhere else, and the latter should be replaced with the actual buckets. This can be done in a later PR.

Also the form points to `/apps/create` which doesn't currently exist.

## How to review

1. log in and click "create new app" on the home page
2. see the new app template

