### PR TITLE
Report errors to Sentry

### DIFF
--- a/app/base/routes.js
+++ b/app/base/routes.js
@@ -6,6 +6,7 @@ module.exports = [
   {name: 'home', pattern: '/', view: views.home},
   {name: 'callback', pattern: '/callback', view: views.auth_callback},
   {name: 'login', pattern: '/login', view: views.login},
-  {name: 'logout', pattern: '/logout', view: views.logout}
+  {name: 'logout', pattern: '/logout', view: views.logout},
+  {name: 'error', pattern: '/error', view: views.error_test}
 
 ];

--- a/app/base/views.js
+++ b/app/base/views.js
@@ -1,6 +1,7 @@
 var api = require('../api-client');
 var passport = require('passport');
 var ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
+var raven = require('raven');
 
 
 exports.home = [
@@ -17,9 +18,17 @@ exports.home = [
 ];
 
 
+exports.error_test = function (req, res, next) {
+  api.users.get('non-existent')
+    .then(function (user) { res.send(user.id); })
+    .catch(next);
+};
+
+
 exports.auth_callback = [
   passport.authenticate('auth0-oidc'),
   function (req, res) {
+    raven.setContext({user: req.user});
     api.set_token(req.user.id_token);
     res.redirect(req.session.returnTo || '/');
   }

--- a/app/config.js
+++ b/app/config.js
@@ -72,6 +72,19 @@ config.api = {
   password: process.env.API_PASSWORD
 };
 
+config.sentry = {
+  dsn: process.env.SENTRY_DSN,
+  options: {
+    autoBreadcrumbs: {
+      console: true,
+      http: true
+    },
+    tags: {
+      environment: process.env.ENV || 'dev'
+    }
+  }
+};
+
 if (PROD) {
   config.express.host = '0.0.0.0';
 }

--- a/app/errors.js
+++ b/app/errors.js
@@ -1,7 +1,16 @@
+var log = require('bole')('error-handler');
+var sentry = require('raven');
 var url_for = require('./routes').url_for;
 
 
+process.on('unhandledRejection', function (error) {
+  log.error(error.message);
+  sentry.captureException(error);
+});
+
+
 module.exports = function (err, req, res, next) {
+  sentry.captureException(err);
 
   if (res.headersSent) {
     return next(err);

--- a/app/index.js
+++ b/app/index.js
@@ -9,10 +9,11 @@ var Strategy = require('passport-auth0-openidconnect').Strategy;
 var assets = require('./assets');
 
 
-bole.output({level: config.log.level, stream: process.stdout});
-
 var app = express();
 app.set('views', __dirname);
+
+bole.output({level: config.log.level, stream: process.stdout});
+app.use(require('morgan')('combined'));
 
 if (process.env.ENV !== 'prod') {
   assets.compile_sass();

--- a/app/index.js
+++ b/app/index.js
@@ -5,12 +5,16 @@ var express = require('express');
 var join = require('path').join;
 var nunjucks = require('nunjucks');
 var passport = require('passport');
+var raven = require('raven');
 var Strategy = require('passport-auth0-openidconnect').Strategy;
 var assets = require('./assets');
 
 
 var app = express();
 app.set('views', __dirname);
+
+raven.config(config.sentry.dsn, config.sentry.options).install();
+app.use(raven.requestHandler());
 
 bole.output({level: config.log.level, stream: process.stdout});
 app.use(require('morgan')('combined'));
@@ -62,6 +66,8 @@ app.use(function (req, res, next) {
 
 var routes = require('./routes');
 app.use(routes.router);
+
+app.use(raven.errorHandler());
 
 app.use(require('./errors'));
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nunjucks": "3.0.1",
     "passport": "^0.4.0",
     "passport-auth0-openidconnect": "^0.1.0",
+    "raven": "^2.2.1",
     "request": "^2.82.0",
     "request-promise": "^4.2.1",
     "request-promise-core": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "govuk_frontend_toolkit": "7.0.0",
     "govuk_template_jinja": "0.22.1",
     "jquery": "^3.2.1",
+    "morgan": "^1.9.0",
     "node-sass": "^4.5.3",
     "nunjucks": "3.0.1",
     "passport": "^0.4.0",


### PR DESCRIPTION
## What

* Add dependency on the `raven` Sentry client
* Configure Sentry client with new `SENTRY_DSN` environment variable
* Send errors and uncaught promise rejections to Sentry
* Added `morgan` for HTTP request logging

## How to review

1. Set the `SENTRY_DSN` environment variable
2. Run the app
3. Browse to `/error` - a testing page
4. See an error message displayed
5. Browse to https://sentry.service.dsd.io/mojds/control-panel-frontend/
6. See the error recorded in Sentry

See [Trello #401](https://trello.com/c/ES3ohbQJ)