### PR TITLE
Admin template to list users in API, tweak "homepage"

### DIFF
--- a/app/assets/sass/local/tables.scss
+++ b/app/assets/sass/local/tables.scss
@@ -5,11 +5,6 @@ table {
   th {
     font-weight: bold;
   }
-  &.list {
-    tr {
-      vertical-align: top;
-    }
-  }
 
   tr {
     th:last-child,

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -7,9 +7,19 @@
   {% if error %}
     <p>{{ error }}</p>
   {% else %}
-    <p><a href="{{ url_for('apps.new') }}" class="button button-secondary">Create new app</a></p>
-    <p><a href="{{ url_for('buckets.new') }}" class="button button-secondary">Create new bucket</a></p>
-    {{ current_user | dump | safe }}
+    <h2 class="heading-medium">Admin</h2>
+    <ul class="list list-bullet">
+      <li><a href="{{ url_for('users.list') }}">List users</a></li>
+    </ul>
+
+    <h2 class="heading-medium">Temporary shortcuts</h2>
+    <ul class="list list-bullet">
+      <li><a href="{{ url_for('apps.new') }}">Create new app</a></li>
+      <li><a href="{{ url_for('buckets.new') }}">Create new bucket</a></li>
+    </ul>
+
+    <h2 class="heading-medium">Logged-in user dump</h2>
+    <p>{{ current_user | dump(2) | safe }}</p>
   {% endif %}
 
 {% endblock %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,13 +1,33 @@
-{% extends "layouts/two-column.html" %}
+{% extends "layouts/one-column.html" %}
 
 {% set page_title = "Users" %}
 
 {% block main_column %}
 
-<ul>
-  {% for user in users.results %}
-  <li><a href="{{ url_for('users.details', {id: user.auth0_id}) }}">{{ user.name | default(user.username, true) }}</a></li>
-  {% endfor %}
-</ul>
+<p>{{ users.results.length }} {{ "user" if users.results.length == 1 else "users" }}</p>
+
+<table class="list">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Username</th>
+      <th>Email</th>
+      <td>&nbsp;</td>
+    </tr>
+  </thead>
+  <tbody>
+    {% for user in users.results %}
+      <tr>
+        <td><a href="{{ url_for('users.details', {id: user.auth0_id}) }}">{{ user.name | default(user.username, true) }}</a></td>
+        <td>{{ user.username }}</td>
+        <td>{{ user.email }}</td>
+        <td class="align-right">
+          <a class="button button-secondary" href="#">Edit</a>
+          <a class="button button-secondary js-confirm" href="#">Delete</a>
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
 
 {% endblock %}


### PR DESCRIPTION
## What

Adds a simple list template that lists all users in the API DB and links to their details page, and arranges the temporary stuff on the "home" page to be a little nicer

## How to review

1. Have at least one user in your local API, ideally more
2. Log in and see the home page, then
3. Click "List users"

