### PR TITLE
Fix header link bug

### DIFF
--- a/app/templates/layouts/base.html
+++ b/app/templates/layouts/base.html
@@ -1,5 +1,3 @@
-{% set homepage_url = '/' %}
-{% set logo_link_title = 'Return to sign in' %}
 {% extends "govuk_template.html" %}
 
 {% block head %}
@@ -16,7 +14,7 @@
     <div class="content">
       <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
       <nav id="proposition-menu">
-        <a href="{{ homeUrl }}" id="proposition-name">
+        <a href="{{ url_for('base.home') }}" id="proposition-name">
           {% block service_name %}
             Analytics Platform Control Panel
           {% endblock %}


### PR DESCRIPTION
## What

The application name link in the header was linking to an empty Nunjucks variable, so was empty, thus linking to the currently displayed page. This now links to the root of the site, as expected.

## How to review

1. Log in
2. Visit any page other than the homepage
3. See that the link "Analytics Platform Control Panel" links to `/` rather than the current page
