### PR TITLE
Add bucket via API on POST of add bucket form

### DIFF
--- a/app/api-client.js
+++ b/app/api-client.js
@@ -9,7 +9,12 @@ module.exports = (function () {
   var token = 'invalid token';
 
   function api_request(options) {
-    return request(override_defaults(options));
+    try {
+      return request(override_defaults(options));
+
+    } catch (error) {
+      throw new Error(`API: ${options.method || 'GET'} ${options.endpoint} failed: ${error}`);
+    }
   }
 
 
@@ -30,7 +35,16 @@ module.exports = (function () {
 
 
   function endpoint_url(endpoint) {
-    return url.resolve(config.api.base_url, '/' + (endpoint + '/' || ''));
+
+    if (!endpoint) {
+      throw new Error('Missing endpoint');
+    }
+
+    if (!endpoint.endsWith('/')) {
+      endpoint += '/';
+    }
+
+    return url.resolve(config.api.base_url, endpoint);
   }
 
 

--- a/app/api-client.js
+++ b/app/api-client.js
@@ -30,7 +30,7 @@ module.exports = (function () {
 
 
   function endpoint_url(endpoint) {
-    return url.resolve(config.api.base_url, '/' + (endpoint || ''));
+    return url.resolve(config.api.base_url, '/' + (endpoint + '/' || ''));
   }
 
 

--- a/app/buckets/routes.js
+++ b/app/buckets/routes.js
@@ -5,6 +5,7 @@ module.exports = [
 
   {name: 'list', pattern: '/buckets', view: views.list_buckets},
   {name: 'new', pattern: '/buckets/new', view: views.new_bucket},
+  {name: 'create', pattern: '/buckets/new', view: views.create_bucket, method: 'POST'},
   {name: 'details', pattern: '/buckets/:id', view: views.bucket_details}
 
 ];

--- a/app/buckets/views.js
+++ b/app/buckets/views.js
@@ -1,6 +1,7 @@
 var api = require('../api-client');
 var bole = require('bole');
 var ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
+var routes = require('../routes');
 
 var log = bole('buckets-views');
 
@@ -21,6 +22,7 @@ exports.list_buckets = [
 
 
 exports.new_bucket = [
+  ensureLoggedIn('/login'),
   function (req, res) {
 
     res.render('buckets/new.html', {
@@ -42,10 +44,9 @@ exports.create_bucket = [
 
     api.buckets.add(bucket)
       .then(function (bucket) {
-        res.redirect(url_for('buckets.details', {id: bucket.id}));
+        res.redirect(routes.url_for('buckets.details', {id: bucket.id}));
       })
       .catch(function (error) {
-        console.dir(error);
         res.render('buckets/new.html', {
           bucket: bucket,
           error: error

--- a/app/buckets/views.js
+++ b/app/buckets/views.js
@@ -20,36 +20,65 @@ exports.list_buckets = [
 ];
 
 
-exports.new_bucket = function (req, res) {
+exports.new_bucket = [
+  function (req, res) {
 
-  res.render('buckets/new.html', {
-    prefix: process.env.ENV + '-'
-  });
-
-};
-
-
-exports.bucket_details = function (req, res) {
-
-  api.get_bucket(req.params.id).then(function (bucket) {
-
-    res.render('buckets/details.html', {
-      bucket: bucket
+    res.render('buckets/new.html', {
+      prefix: process.env.ENV + '-'
     });
 
-  }).catch(function (err) {
+  }
+];
 
-    bucket = {
-      id: 999,
-      url: 'http://api:8000/s3buckets/999',
-      name: 'dev-dummy-bucket',
-      apps3buckets: [],
-      created_by: 'github|123456'
+
+exports.create_bucket = [
+  ensureLoggedIn('/login'),
+  function (req, res, next) {
+
+    var bucket = {
+      name: req.body['new-datasource-name'],
+      apps3buckets: []
     };
 
-    res.render('buckets/details.html', {
-      bucket: bucket
-    });
+    api.buckets.add(bucket)
+      .then(function (bucket) {
+        res.redirect(url_for('buckets.details', {id: bucket.id}));
+      })
+      .catch(function (error) {
+        console.dir(error);
+        res.render('buckets/new.html', {
+          bucket: bucket,
+          error: error
+        });
+      });
+  }
+];
 
-  });
-};
+
+exports.bucket_details = [
+  ensureLoggedIn('/login'),
+  function (req, res) {
+
+    api.get_bucket(req.params.id).then(function (bucket) {
+
+      res.render('buckets/details.html', {
+        bucket: bucket
+      });
+
+    }).catch(function (err) {
+
+      bucket = {
+        id: 999,
+        url: 'http://api:8000/s3buckets/999',
+        name: 'dev-dummy-bucket',
+        apps3buckets: [],
+        created_by: 'github|123456'
+      };
+
+      res.render('buckets/details.html', {
+        bucket: bucket
+      });
+
+    });
+  }
+];

--- a/app/errors.js
+++ b/app/errors.js
@@ -1,6 +1,5 @@
 var log = require('bole')('error-handler');
 var sentry = require('raven');
-var url_for = require('./routes').url_for;
 
 
 process.on('unhandledRejection', function (error) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -86,11 +86,28 @@ function add_route(app_name) {
 
     log.debug(route.name + ': ' + route.pattern);
 
-    exports.router.all(route.pattern, route.view);
+    if (!route.method) {
+      route.method = 'get';
+    }
+
+    route.method = route.method.toLowerCase();
+
+    if (valid_method(route.method)) {
+      exports.router[route.method](route.pattern, route.view);
+
+    } else {
+      throw new Error('Invalid method "' + route.method.toUpperCase() + '" in route ' + route);
+    }
 
     return route;
   };
 }
+
+
+function valid_method(method) {
+  return ['get', 'post', 'put', 'delete'].indexOf(method) >= 0;
+}
+
 
 // static routes
 Object.keys(config.static.paths).forEach(function (pattern) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -92,7 +92,7 @@ function add_route(app_name) {
 
     route.method = route.method.toLowerCase();
 
-    if (valid_method(route.method)) {
+    if (is_valid_method(route.method)) {
       exports.router[route.method](route.pattern, route.view);
 
     } else {
@@ -104,7 +104,7 @@ function add_route(app_name) {
 }
 
 
-function valid_method(method) {
+function is_valid_method(method) {
   return ['get', 'post', 'put', 'delete'].indexOf(method) >= 0;
 }
 

--- a/app/templates/buckets/includes/new-bucket-name.html
+++ b/app/templates/buckets/includes/new-bucket-name.html
@@ -2,4 +2,9 @@
   App data source (bucket) name
   <span class="form-hint">60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "{{ prefix }}"</span>
 </label>
-<input class="form-control" name="new-datasource-name" type="text" id="new-datasource-name" value="{{ prefix }}" data-prefix="{{ prefix }}" pattern="[a-z0-9.-]{1,60}" maxlength="60">
+{% if error.error.name %}
+<span class="error-message">
+  {{ error.error.name }}
+</span>
+{% endif %}
+<input class="form-control" name="new-datasource-name" type="text" id="new-datasource-name" value="{{ prefix }}" data-prefix="{{ prefix }}" pattern="[a-z0-9.-]{1,60}" maxlength="60" value="{{ bucket.name }}">

--- a/app/templates/buckets/new.html
+++ b/app/templates/buckets/new.html
@@ -4,9 +4,13 @@
 
 {% block main_column %}
 
-<form action="/buckets/create" method="post">
+{% if error and not error.error %}
+<div class="error">{{ error.message }}</div>
+{% endif %}
 
-  <div class="form-group">
+<form action="{{ url_for('buckets.create') }}" method="post">
+
+  <div class="form-group{% if error.error.name %} form-group-error{% endif %}">
     {% include 'buckets/includes/new-bucket-name.html' %}
   </div>
 

--- a/app/templates/buckets/new.html
+++ b/app/templates/buckets/new.html
@@ -4,20 +4,20 @@
 
 {% block main_column %}
 
-{% if error and not error.error %}
-<div class="error">{{ error.message }}</div>
-{% endif %}
+  {% if error and not error.error %}
+    <div class="error">{{ error.message }}</div>
+  {% endif %}
 
-<form action="{{ url_for('buckets.create') }}" method="post">
+  <form action="{{ url_for('buckets.create') }}" method="post">
 
-  <div class="form-group{% if error.error.name %} form-group-error{% endif %}">
-    {% include 'buckets/includes/new-bucket-name.html' %}
-  </div>
+    <div class="form-group{% if error.error.name %} form-group-error{% endif %}">
+      {% include 'buckets/includes/new-bucket-name.html' %}
+    </div>
 
-  <div class="form-group">
-    <input type="submit" class="button button-secondary" value="Create">
-  </div>
+    <div class="form-group">
+      <input type="submit" class="button button-secondary" value="Create">
+    </div>
 
-</form>
+  </form>
 
 {% endblock %}

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,10 +1,13 @@
 "use strict";
 var config = require('../app/config');
 var nock = require('nock');
+var routes = require('../app/routes');
 
 
 module.exports = {
 
-  api: nock(config.api.base_url)
+  api: nock(config.api.base_url),
+
+  url_for: routes.url_for
 
 };

--- a/test/mock.js
+++ b/test/mock.js
@@ -1,0 +1,10 @@
+"use strict";
+var config = require('../app/config');
+var nock = require('nock');
+
+
+module.exports = {
+
+  api: nock(config.api.base_url)
+
+};

--- a/test/test-api-client.js
+++ b/test/test-api-client.js
@@ -1,11 +1,8 @@
 "use strict";
 var assert = require('chai').assert;
-var nock = require('nock');
+var mock = require('./mock');
 
 var api = require('../app/api-client');
-
-
-var test_server = nock('http://localhost:8000');
 
 
 describe('API Client', function () {
@@ -16,7 +13,7 @@ describe('API Client', function () {
       var reason = {
         'detail': 'Authentication credentials were not provided.'};
 
-      test_server
+      mock.api
         .get('/apps/')
         .matchHeader('Authorization', 'JWT invalid token')
         .reply(403, reason);
@@ -35,7 +32,7 @@ describe('API Client', function () {
         'results': []
       };
 
-      test_server
+      mock.api
         .get('/apps/')
         .matchHeader('Authorization', 'JWT ' + valid_token)
         .reply(200, response);

--- a/test/test-api-client.js
+++ b/test/test-api-client.js
@@ -17,7 +17,7 @@ describe('API Client', function () {
         'detail': 'Authentication credentials were not provided.'};
 
       test_server
-        .get('/apps')
+        .get('/apps/')
         .matchHeader('Authorization', 'JWT invalid token')
         .reply(403, reason);
 
@@ -36,7 +36,7 @@ describe('API Client', function () {
       };
 
       test_server
-        .get('/apps')
+        .get('/apps/')
         .matchHeader('Authorization', 'JWT ' + valid_token)
         .reply(200, response);
 

--- a/test/test-apps.js
+++ b/test/test-apps.js
@@ -16,7 +16,7 @@ describe('Apps API', function () {
       var response = require('./test-apps-response');
 
       mock_api
-        .get('/apps')
+        .get('/apps/')
         .reply(200, response);
 
       return apps.list()

--- a/test/test-apps.js
+++ b/test/test-apps.js
@@ -1,11 +1,7 @@
 "use strict";
 var assert = require('chai').assert;
-var nock = require('nock');
-
+var mock = require('./mock');
 var apps = require('../app/api-client.js').apps;
-
-
-var mock_api = nock('http://localhost:8000');
 
 
 describe('Apps API', function () {
@@ -15,7 +11,7 @@ describe('Apps API', function () {
     it('returns a list of apps', function () {
       var response = require('./test-apps-response');
 
-      mock_api
+      mock.api
         .get('/apps/')
         .reply(200, response);
 
@@ -35,7 +31,7 @@ describe('Apps API', function () {
         "userapps": ["This field is required."]
       };
 
-      mock_api
+      mock.api
         .post('/apps/', JSON.stringify({}))
         .reply(400, response);
 
@@ -52,7 +48,7 @@ describe('Apps API', function () {
         "userapps": ["This field is required."]
       };
 
-      mock_api
+      mock.api
         .post('/apps/', JSON.stringify(incomplete_app_data))
         .reply(400, response);
 
@@ -84,7 +80,7 @@ describe('Apps API', function () {
         "userapps": []
       };
 
-      mock_api
+      mock.api
         .post('/apps/', JSON.stringify(test_app))
         .reply(201, response);
 

--- a/test/test-buckets-views.js
+++ b/test/test-buckets-views.js
@@ -1,0 +1,53 @@
+"use strict";
+var assert = require('chai').assert;
+var config = require('../app/config');
+var mock = require('./mock');
+var views = require('../app/buckets/views');
+
+
+describe('buckets view', function () {
+
+  describe('add bucket', function () {
+
+    it('creates a new bucket and redirects', function () {
+      var bucket_data = {
+        'new-datasource-name': 'dev-test-bucket'
+      };
+      var created_bucket = {
+        id: 1,
+        url: config.api.base_url + '/s3buckets/1/',
+        name: 'dev-test-bucket',
+        arn: 'arn:aws:s3:::dev-test-bucket',
+        apps3buckets: [],
+        created_by: 'github|12345'
+      };
+
+      mock.api
+        .post('/s3buckets/')
+        .reply(201, created_bucket);
+
+      var req = {};
+      var res = {};
+      var request = new Promise(function (resolve, reject) {
+
+        function unexpected(template, options) {
+          options = JSON.stringify(options);
+          reject(new Error(
+            `expected redirect, got rendered template ${template}, ${options}`));
+        }
+
+        req.body = bucket_data;
+        res.redirect = resolve;
+        res.render = unexpected;
+        views.create_bucket[1](req, res, reject);
+      });
+
+      return request
+        .then(function (redirect_url) {
+          assert.equal(redirect_url, mock.url_for('buckets.details', {id: created_bucket.id}));
+        });
+    });
+
+  });
+
+});

--- a/test/test-buckets.js
+++ b/test/test-buckets.js
@@ -16,7 +16,7 @@ describe('buckets API', function () {
       var response = require('./test-buckets-response');
 
       mock_api
-        .get('/s3buckets')
+        .get('/s3buckets/')
         .reply(200, response);
 
       return buckets.list()
@@ -34,7 +34,7 @@ describe('buckets API', function () {
       };
 
       mock_api
-        .post('/s3buckets', JSON.stringify({}))
+        .post('/s3buckets/', JSON.stringify({}))
         .reply(400, error);
 
       return buckets.add({})
@@ -49,7 +49,7 @@ describe('buckets API', function () {
       };
 
       mock_api
-        .post('/s3buckets', JSON.stringify(incomplete_bucket_data))
+        .post('/s3buckets/', JSON.stringify(incomplete_bucket_data))
         .reply(400, error);
 
       return buckets.add(incomplete_bucket_data)
@@ -67,7 +67,7 @@ describe('buckets API', function () {
       };
 
       mock_api
-        .post('/s3buckets', JSON.stringify(invalid_bucket_data))
+        .post('/s3buckets/', JSON.stringify(invalid_bucket_data))
         .reply(400, error);
 
       return buckets.add(invalid_bucket_data)
@@ -94,7 +94,7 @@ describe('buckets API', function () {
       };
 
       mock_api
-        .post('/s3buckets', JSON.stringify(test_bucket))
+        .post('/s3buckets/', JSON.stringify(test_bucket))
         .reply(201, response);
 
       return buckets.add(test_bucket)

--- a/test/test-buckets.js
+++ b/test/test-buckets.js
@@ -1,11 +1,7 @@
 "use strict";
 var assert = require('chai').assert;
-var nock = require('nock');
-
+var mock = require('./mock');
 var buckets = require('../app/api-client.js').buckets;
-
-
-var mock_api = nock('http://localhost:8000');
 
 
 describe('buckets API', function () {
@@ -15,7 +11,7 @@ describe('buckets API', function () {
     it('returns a list of buckets', function () {
       var response = require('./test-buckets-response');
 
-      mock_api
+      mock.api
         .get('/s3buckets/')
         .reply(200, response);
 
@@ -33,7 +29,7 @@ describe('buckets API', function () {
         'apps3buckets': ['This field is required.']
       };
 
-      mock_api
+      mock.api
         .post('/s3buckets/', JSON.stringify({}))
         .reply(400, error);
 
@@ -48,7 +44,7 @@ describe('buckets API', function () {
         'apps3buckets': ['This field is required.']
       };
 
-      mock_api
+      mock.api
         .post('/s3buckets/', JSON.stringify(incomplete_bucket_data))
         .reply(400, error);
 
@@ -66,7 +62,7 @@ describe('buckets API', function () {
         'name': ['Name must have correct env prefix e.g. dev-bucketname']
       };
 
-      mock_api
+      mock.api
         .post('/s3buckets/', JSON.stringify(invalid_bucket_data))
         .reply(400, error);
 
@@ -93,7 +89,7 @@ describe('buckets API', function () {
         "created_by": "github|12345"
       };
 
-      mock_api
+      mock.api
         .post('/s3buckets/', JSON.stringify(test_bucket))
         .reply(201, response);
 

--- a/test/test-users.js
+++ b/test/test-users.js
@@ -1,11 +1,7 @@
 "use strict";
 var assert = require('chai').assert;
-var nock = require('nock');
-
+var mock = require('./mock');
 var users = require('../app/api-client.js').users;
-
-
-var mock_api = nock('http://localhost:8000');
 
 
 describe('Users API', function () {
@@ -15,7 +11,7 @@ describe('Users API', function () {
     it('returns a list of users', function () {
       var response = require('./test-users-response');
 
-      mock_api
+      mock.api
         .get('/users/')
         .reply(200, response);
 
@@ -35,7 +31,7 @@ describe('Users API', function () {
         "users3buckets": ["This field is required."]
       }
 
-      mock_api
+      mock.api
         .post('/users/', JSON.stringify({}))
         .reply(400, error);
 
@@ -52,7 +48,7 @@ describe('Users API', function () {
         "users3buckets": ["This field is required."]
       }
 
-      mock_api
+      mock.api
         .post('/users/', JSON.stringify(incomplete_user_data))
         .reply(400, error);
 
@@ -81,7 +77,7 @@ describe('Users API', function () {
         "users3buckets": []
       };
 
-      mock_api
+      mock.api
         .post('/users/', JSON.stringify(test_user))
         .reply(201, response);
 

--- a/test/test-users.js
+++ b/test/test-users.js
@@ -16,7 +16,7 @@ describe('Users API', function () {
       var response = require('./test-users-response');
 
       mock_api
-        .get('/users')
+        .get('/users/')
         .reply(200, response);
 
       return users.list()
@@ -36,7 +36,7 @@ describe('Users API', function () {
       }
 
       mock_api
-        .post('/users', JSON.stringify({}))
+        .post('/users/', JSON.stringify({}))
         .reply(400, error);
 
       return users.add({})
@@ -53,7 +53,7 @@ describe('Users API', function () {
       }
 
       mock_api
-        .post('/users', JSON.stringify(incomplete_user_data))
+        .post('/users/', JSON.stringify(incomplete_user_data))
         .reply(400, error);
 
       return users.add(incomplete_user_data)
@@ -82,7 +82,7 @@ describe('Users API', function () {
       };
 
       mock_api
-        .post('/users', JSON.stringify(test_user))
+        .post('/users/', JSON.stringify(test_user))
         .reply(201, response);
 
       return users.add(test_user)


### PR DESCRIPTION
## What

* Refactored routing setup to allow a route to specify which HTTP method to match
* Added a view and route to handle a POST request from the add bucket form
* Added an integration test for the view

## How to review

1. Run the app
2. Login
3. Click on the `Create new bucket` button
4. Enter a name and submit the form
5. See in S3 that a bucket with the specified name has been created
6. See the JSON representation of the bucket model displayed

See [Trello #442](https://trello.com/c/scu4u4ZD)