### PR TITLE
Request user data from API on authentication

### DIFF
--- a/app/base/views.js
+++ b/app/base/views.js
@@ -27,10 +27,14 @@ exports.error_test = function (req, res, next) {
 
 exports.auth_callback = [
   passport.authenticate('auth0-oidc'),
-  function (req, res) {
+  function (req, res, next) {
     raven.setContext({user: req.user});
     api.set_token(req.user.id_token);
-    res.redirect(req.session.returnTo || '/');
+    api.users.get(req.user.sub)
+      .then((user) => {
+        res.redirect(req.session.returnTo || '/');
+      })
+      .catch(next);
   }
 ];
 

--- a/app/config.js
+++ b/app/config.js
@@ -85,6 +85,14 @@ config.sentry = {
   }
 };
 
+config.auth0 = {
+  domain: process.env.AUTH0_DOMAIN,
+  clientID: process.env.AUTH0_CLIENT_ID,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  callbackURL: process.env.AUTH0_CALLBACK_URL || 'http://localhost:3000/callback',
+  passReqToCallback: true
+};
+
 if (PROD) {
   config.express.host = '0.0.0.0';
 }

--- a/app/index.js
+++ b/app/index.js
@@ -33,18 +33,12 @@ app.use(require('cookie-parser')());
 app.use(require('body-parser').urlencoded({ extended: true }));
 app.use(require('express-session')(config.session));
 
-passport.use(new Strategy({
-    domain: process.env.AUTH0_DOMAIN,
-    clientID: process.env.AUTH0_CLIENT_ID,
-    clientSecret: process.env.AUTH0_CLIENT_SECRET,
-    callbackURL: process.env.AUTH0_CALLBACK_URL,
-    passReqToCallback: true
-  },
-  function (req, issuer, audience, profile, accessToken, refreshToken, params, cb) {
+passport.use(new Strategy(
+  config.auth0,
+  (req, issuer, audience, profile, accessToken, refreshToken, params, cb) => {
     profile._json.id_token = params.id_token;
     return cb(null, profile._json);
-  }
-));
+  }));
 
 passport.serializeUser(function(user, done) {
   done(null, user);

--- a/test/test-login.js
+++ b/test/test-login.js
@@ -1,0 +1,52 @@
+"use strict";
+const assert = require('chai').assert;
+const config = require('../app/config');
+const mock = require('./mock');
+const nock = require('nock');
+const views = require('../app/base/views');
+
+
+describe('Logging in', () => {
+
+  describe('an authenticated user', () => {
+
+    it('fetches the API user details', () => {
+      var next_url = '/';
+      var id_token = 'test-token'
+      var sub = 'github|12345';
+
+      var user = {
+        'auth0_id': sub,
+        'url': 'http://localhost:8000/users/github%7C12345/',
+        'username': 'test',
+        'name': 'Test User',
+        'email': 'test@example.com',
+        'groups': [],
+        'userapps': [],
+        'users3buckets': []
+      };
+
+      var request = new Promise((resolve, reject) => {
+        var req = {
+          user: {id_token: id_token, sub: sub},
+          session: {returnTo: next_url}
+        };
+        var res = {redirect: resolve};
+        views.auth_callback[1](req, res, reject);
+      });
+
+      var user_details_request = mock.api
+        .get(`/users/${escape(user.auth0_id)}/`)
+        .matchHeader('Authorization', `JWT ${id_token}`)
+        .reply(200, user);
+
+      return request
+        .then((redirect_url) => {
+          assert.equal(redirect_url, next_url);
+          assert(user_details_request.isDone(), 'API call expected');
+        });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What

* Make a request to the API to fetch the user that has just authenticated, to give the API a chance to create the user in the database if it does not exist.

## How to review

No obvious change, but there is a new passing test

See [Trello #451](https://trello.com/c/lBz5zvth)
