### PR TITLE
Fix unrecognized user login

### DIFF
--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -24,7 +24,7 @@ moj.Modules.auth0lock = {
       callbackURL: callbackurl,
       responseType: "code",
       authParams: {
-        scope: "openid offline_access"
+        scope: "openid profile offline_access"
       },
       container: self.containerId
     });


### PR DESCRIPTION
## What

* Add `profile` scope to Auth0 authentication request, so that we receive their `nickname`