### PR TITLE
Add `GET /buckets/:id/edit` endpoint

### DIFF
--- a/app/buckets/routes.js
+++ b/app/buckets/routes.js
@@ -6,6 +6,7 @@ module.exports = [
   {name: 'list', pattern: '/buckets', view: views.list_buckets},
   {name: 'new', pattern: '/buckets/new', view: views.new_bucket},
   {name: 'create', pattern: '/buckets/new', view: views.create_bucket, method: 'POST'},
-  {name: 'details', pattern: '/buckets/:id', view: views.bucket_details}
+  {name: 'details', pattern: '/buckets/:id', view: views.bucket_details},
+  {name: 'edit', pattern: '/buckets/:id/edit', view: views.bucket_edit},
 
 ];

--- a/app/buckets/views.js
+++ b/app/buckets/views.js
@@ -83,3 +83,25 @@ exports.bucket_details = [
     });
   }
 ];
+
+exports.bucket_edit = [
+  ensureLoggedIn('/login'),
+  function(req, res, next) {
+    let bucket_request = api.get_bucket(req.params.id);
+    let apps_request = api.list_apps();
+    let users_request = api.list_users();
+
+    Promise
+      .all([bucket_request, apps_request, users_request])
+      .then((responses) => {
+        let [bucket_response, apps_response, users_response] = responses;
+        let template_args = {
+          bucket: bucket_response,
+          apps: apps_response.results,
+          users: users_response.results,
+        };
+        res.render('buckets/edit.html', template_args);
+      })
+      .catch(next)
+  },
+];

--- a/app/templates/buckets/edit.html
+++ b/app/templates/buckets/edit.html
@@ -1,0 +1,13 @@
+{% extends "layouts/one-column.html" %}
+
+{% set page_title = "Bucket: " + bucket.name %}
+
+{% block main_column %}
+
+<pre>bucket = {{ bucket | dump(4) | safe }}</pre>
+<br />
+<pre>apps = {{ apps | dump(4) | safe }}</pre>
+<br />
+<pre>users = {{ users | dump(4) | safe }}</pre>
+
+{% endblock %}

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -19,7 +19,7 @@
         <tr>
           <td><a href="{{ url_for('buckets.details', {id: bucket.id}) }}">{{ bucket.name }}</a></td>
           <td class="align-right">
-            <a class="button button-secondary" href="#">Edit</a>
+            <a class="button button-secondary" href="{{ url_for('buckets.edit', {id: bucket.id}) }}">Edit</a>
             <a class="button button-secondary js-confirm" href="#">Delete</a>
           </td>
         </tr>

--- a/test/fixtures/apps.js
+++ b/test/fixtures/apps.js
@@ -1,0 +1,29 @@
+module.exports = {
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": 1,
+      "url": "http://localhost:8000/apps/1/",
+      "name": "aldo-test-app",
+      "slug": "aldo-test-app",
+      "repo_url": "https://www.example.com/aldo-test-app",
+      "iam_role_name": "dev_app_aldo-test-app",
+      "created_by": "github|12345",
+      "apps3buckets": [],
+      "userapps": []
+    },
+    {
+      "id": 2,
+      "url": "http://localhost:8000/apps/2/",
+      "name": "other-test-app",
+      "slug": "other-test-app",
+      "repo_url": "https://www.example.com/other-test-app",
+      "iam_role_name": "dev_app_other-test-app",
+      "created_by": "github|12345",
+      "apps3buckets": [],
+      "userapps": []
+    }
+  ]
+}

--- a/test/fixtures/bucket.js
+++ b/test/fixtures/bucket.js
@@ -1,0 +1,8 @@
+module.exports = {
+  "id": 1,
+  "url": "http://localhost:8000/s3buckets/1/",
+  "name": "test-bucket-1",
+  "arn": "arn:aws:s3:::test-bucket-1",
+  "apps3buckets": [],
+  "created_by": null
+}

--- a/test/test-app-edit.js
+++ b/test/test-app-edit.js
@@ -27,7 +27,7 @@ describe('Edit app form', () => {
         .get(`/users/`)
         .reply(200, users);
 
-      let req = {'params': {'id': 1}};
+      let req = {'params': {'id': app.id}};
       let res = {};
       let request = new Promise((resolve, reject) => {
 

--- a/test/test-app-edit.js
+++ b/test/test-app-edit.js
@@ -12,9 +12,9 @@ describe('Edit app form', () => {
   describe('when rendered', () => {
 
     it('loads app, buckets and users from API', () => {
-      const app = require('./fixtures/app')
-      const buckets = require('./fixtures/buckets')
-      const users = require('./fixtures/users')
+      const app = require('./fixtures/app');
+      const buckets = require('./fixtures/buckets');
+      const users = require('./fixtures/users');
 
       // Mock API requests
       let app_details_request = nock(config.api.base_url)
@@ -27,13 +27,13 @@ describe('Edit app form', () => {
         .get(`/users/`)
         .reply(200, users);
 
-      let req = {'params': {'id': app.id}};
-      let res = {};
       let request = new Promise((resolve, reject) => {
-
-        res.render = function (template, context) {
-          resolve({'template': template, 'context': context});
-        }
+        let req = {params: {id: app.id}};
+        let res = {
+          render: (template, context) => {
+            resolve({'template': template, 'context': context});
+          }
+        };
 
         views.app_edit[1](req, res, reject);
       });

--- a/test/test-bucket-edit.js
+++ b/test/test-bucket-edit.js
@@ -17,22 +17,23 @@ describe('Edit bucket form', () => {
       const users = require('./fixtures/users');
 
       // Mock API requests
-      let bucket_details_request = nock(config.api.base_url)
+      const bucket_details_request = nock(config.api.base_url)
         .get(`/s3buckets/${bucket.id}/`)
         .reply(200, bucket);
-      let apps_list_request = nock(config.api.base_url)
+      const apps_list_request = nock(config.api.base_url)
         .get(`/apps/`)
         .reply(200, apps);
-      let users_list_request = nock(config.api.base_url)
+      const users_list_request = nock(config.api.base_url)
         .get(`/users/`)
         .reply(200, users);
 
-      let req = {params: {id: bucket.id}};
-      let res = {};
-      let request = new Promise((resolve, reject) => {
-        res.render = function (template, context) {
-          resolve({'template': template, 'context': context});
-        }
+      const request = new Promise((resolve, reject) => {
+        const req = {params: {id: bucket.id}};
+        const res = {
+          render: (template, context) => {
+            resolve({template: template, context: context});
+          },
+        };
 
         views.bucket_edit[1](req, res, reject);
       });


### PR DESCRIPTION
### What

It renders `buckets/edit.html` which currently just dumps the template context (`bucket`, `apps` and `users`).

The list of apps and users is used to populate the forms to grant access to the bucket to apps/users (similarly to what's done in the app view).

### Ticket
https://trello.com/c/nOIbztRT/448-fetch-lists-of-users-and-apps-for-grant-access-to-bucket-form-1