### PR TITLE
Show a friendly message to non superusers

### DIFF
--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -4,8 +4,10 @@
 
 {% block main_column %}
 
-  {% if error %}
-    <p>{{ error }}</p>
+  {% if not current_user.is_superuser %}
+    <h2 class="heading-medium">No access yet</h2>
+    <p>Only superadmins have access to the control panel at the moment.</p>
+    <p>Ask a superadmin to grant you access.</p>
   {% else %}
     <h2 class="heading-medium">Admin</h2>
     <ul class="list list-bullet">


### PR DESCRIPTION
## What

* Catch API 403 error on login and set flag on user session to show a friendly error message instead of a 500 error page

## How to review

1. Set your user attribute `is_superuser` to `False` in your database

    ```sh
    docker-compose exec api python3 manage.py shell
    ```
    then
    ```python
    from control_panel_api.models import User
    me = User.objects.get(username='my username')
    me.is_superuser = False
    me.save()
    exit()
    ```
2. Login to the frontend
3. See a friendly error message