### PR TITLE
Add `GET /users/:id/edit` endpoint

### DIFF
--- a/app/templates/users/edit.html
+++ b/app/templates/users/edit.html
@@ -1,0 +1,13 @@
+{% extends "layouts/one-column.html" %}
+
+{% set page_title = "User: " + user.username %}
+
+{% block main_column %}
+
+<pre>user = {{ user | dump(4) | safe }}</pre>
+<br />
+<pre>apps = {{ apps | dump(4) | safe }}</pre>
+<br />
+<pre>buckets = {{ buckets | dump(4) | safe }}</pre>
+
+{% endblock %}

--- a/app/templates/users/edit.html
+++ b/app/templates/users/edit.html
@@ -6,8 +6,8 @@
 
 <pre>user = {{ user | dump(4) | safe }}</pre>
 <br />
-<pre>apps = {{ apps | dump(4) | safe }}</pre>
+<pre>apps_options = {{ apps_options | dump(4) | safe }}</pre>
 <br />
-<pre>buckets = {{ buckets | dump(4) | safe }}</pre>
+<pre>buckets_options = {{ buckets_options | dump(4) | safe }}</pre>
 
 {% endblock %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -22,7 +22,7 @@
         <td>{{ user.username }}</td>
         <td>{{ user.email }}</td>
         <td class="align-right">
-          <a class="button button-secondary" href="#">Edit</a>
+          <a class="button button-secondary" href="{{ url_for('users.edit', {id: user.auth0_id}) }}">Edit</a>
           <a class="button button-secondary js-confirm" href="#">Delete</a>
         </td>
       </tr>

--- a/app/users/routes.js
+++ b/app/users/routes.js
@@ -5,6 +5,7 @@ module.exports = [
 
   {name: 'new', pattern: '/users/new', view: views.new_user},
   {name: 'list', pattern: '/users', view: views.list_users},
-  {name: 'details', pattern: '/users/:id', view: views.user_details}
+  {name: 'details', pattern: '/users/:id', view: views.user_details},
+  {name: 'edit', pattern: '/users/:id/edit', view: views.user_edit},
 
 ];

--- a/app/users/views.js
+++ b/app/users/views.js
@@ -46,3 +46,25 @@ exports.user_details = [
       .catch(next);
   }
 ];
+
+exports.user_edit = [
+  ensureLoggedIn('/login'),
+  function(req, res, next) {
+    let user_request = api.get_user(req.params.id);
+    let apps_request = api.list_apps();
+    let buckets_request = api.list_buckets();
+
+    Promise
+      .all([user_request, apps_request, buckets_request])
+      .then((responses) => {
+        let [user_response, apps_response, buckets_response] = responses;
+        let template_args = {
+          user: user_response,
+          apps: apps_response.results,
+          buckets: buckets_response.results,
+        };
+        res.render('users/edit.html', template_args);
+      })
+      .catch(next)
+  },
+];

--- a/app/users/views.js
+++ b/app/users/views.js
@@ -57,11 +57,29 @@ exports.user_edit = [
     Promise
       .all([user_request, apps_request, buckets_request])
       .then((responses) => {
-        let [user_response, apps_response, buckets_response] = responses;
+        const [user_response, apps_response, buckets_response] = responses;
+
+        const all_apps = apps_response.results;
+        const all_buckets = buckets_response.results;
+
+        const app_ids_associated = user_response
+          .userapps
+          .map(ua => ua.app.id);
+        const bucket_ids_associated = user_response
+          .users3buckets
+          .map(as => as.s3bucket.id);
+
+        const apps_available = all_apps.filter(app => {
+          return app_ids_associated.indexOf(app.id) < 0;
+        });
+        const buckets_available = all_buckets.filter(bucket => {
+          return bucket_ids_associated.indexOf(bucket.id) < 0;
+        });
+
         let template_args = {
           user: user_response,
-          apps: apps_response.results,
-          buckets: buckets_response.results,
+          apps_available: apps_available,
+          buckets_available: buckets_available,
         };
         res.render('users/edit.html', template_args);
       })

--- a/app/users/views.js
+++ b/app/users/views.js
@@ -61,9 +61,9 @@ const get_buckets_options = (user, all_buckets) => {
 exports.user_edit = [
   ensureLoggedIn('/login'),
   function(req, res, next) {
-    let user_request = api.get_user(req.params.id);
-    let apps_request = api.list_apps();
-    let buckets_request = api.list_buckets();
+    const user_request = api.get_user(req.params.id);
+    const apps_request = api.list_apps();
+    const buckets_request = api.list_buckets();
 
     Promise
       .all([user_request, apps_request, buckets_request])
@@ -72,7 +72,7 @@ exports.user_edit = [
         const all_apps = apps_response.results;
         const all_buckets = buckets_response.results;
 
-        let template_args = {
+        const template_args = {
           user: user,
           apps_options: get_apps_options(user, all_apps),
           buckets_options: get_buckets_options(user, all_buckets),

--- a/test/fixtures/user.js
+++ b/test/fixtures/user.js
@@ -20,5 +20,18 @@ module.exports = {
       "is_admin": true
     }
   ],
-  "users3buckets": []
+  "users3buckets": [
+    {
+      "id": 1,
+      "s3bucket": {
+        "id": 1,
+        "url": "http://localhost:8000/s3buckets/1/",
+        "name": "test-bucket-1",
+        "arn": "arn:aws:s3:::test-bucket-1",
+        "created_by": null
+      },
+      "access_level": "readwrite",
+      "is_admin": true
+    }
+  ]
 }

--- a/test/fixtures/user.js
+++ b/test/fixtures/user.js
@@ -1,0 +1,24 @@
+module.exports = {
+  "auth0_id": "github|1",
+  "url": "http://localhost:8000/users/github%7C1/",
+  "username": "xoen",
+  "name": "",
+  "email": "",
+  "groups": [],
+  "userapps": [
+    {
+      "id": 1,
+      "app": {
+        "id": 1,
+        "url": "http://localhost:8000/apps/1/",
+        "name": "test-app",
+        "slug": "test-app",
+        "repo_url": "https://www.example.com/test-app",
+        "iam_role_name": "dev_app_test-app",
+        "created_by": "github|1"
+      },
+      "is_admin": true
+    }
+  ],
+  "users3buckets": []
+}

--- a/test/test-user-edit.js
+++ b/test/test-user-edit.js
@@ -45,8 +45,8 @@ describe('Edit user form', () => {
           assert(buckets_list_request.isDone(), 'API call to /s3buckets/ expected');
           assert.equal(args.template, 'users/edit.html');
           assert.deepEqual(args.context.user, user);
-          assert.deepEqual(args.context.apps, apps.results);
-          assert.deepEqual(args.context.buckets, buckets.results);
+          assert.deepEqual(args.context.apps_available, [apps.results[1]]);
+          assert.deepEqual(args.context.buckets_available, [buckets.results[1]]);
         });
     });
 

--- a/test/test-user-edit.js
+++ b/test/test-user-edit.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require('chai').assert;
+const nock = require('nock');
+
+const config = require('../app/config');
+const views = require('../app/users/views');
+
+
+describe('Edit user form', () => {
+
+  describe('when rendered', () => {
+
+    it('loads user, apps and buckets from API', () => {
+      const user = require('./fixtures/user');
+      const apps = require('./fixtures/apps');
+      const buckets = require('./fixtures/buckets');
+
+      // Mock API requests
+      const user_details_request = nock(config.api.base_url)
+        .get(`/users/${user.id}/`)
+        .reply(200, user);
+      const apps_list_request = nock(config.api.base_url)
+        .get(`/apps/`)
+        .reply(200, apps);
+      const buckets_list_request = nock(config.api.base_url)
+        .get(`/s3buckets/`)
+        .reply(200, buckets);
+
+      const request = new Promise((resolve, reject) => {
+        const req = {params: {id: user.id}};
+        const res = {
+          render: (template, context) => {
+            resolve({template: template, context: context});
+          },
+        };
+
+        views.user_edit[1](req, res, reject);
+      });
+
+      return request
+        .then((args) => {
+          assert(user_details_request.isDone(), `API call to /users/${user.id}/ expected`);
+          assert(apps_list_request.isDone(), 'API call to /apps/ expected');
+          assert(buckets_list_request.isDone(), 'API call to /s3buckets/ expected');
+          assert.equal(args.template, 'users/edit.html');
+          assert.deepEqual(args.context.user, user);
+          assert.deepEqual(args.context.apps, apps.results);
+          assert.deepEqual(args.context.buckets, buckets.results);
+        });
+    });
+
+  });
+
+});

--- a/test/test-user-edit.js
+++ b/test/test-user-edit.js
@@ -45,8 +45,8 @@ describe('Edit user form', () => {
           assert(buckets_list_request.isDone(), 'API call to /s3buckets/ expected');
           assert.equal(args.template, 'users/edit.html');
           assert.deepEqual(args.context.user, user);
-          assert.deepEqual(args.context.apps_available, [apps.results[1]]);
-          assert.deepEqual(args.context.buckets_available, [buckets.results[1]]);
+          assert.deepEqual(args.context.apps_options, [apps.results[1]]);
+          assert.deepEqual(args.context.buckets_options, [buckets.results[1]]);
         });
     });
 


### PR DESCRIPTION
### What

This endpoint renders `users.edit.html` passing the following context:

```json
{
    "user": {},
    "apps_options": [],
    "buckets_options": []
}
```

Where the `(apps|buckets)_options` is the list of apps/buckets not already associated with the user.

### Ticket

https://trello.com/c/nOIbztRT/448-fetch-lists-of-buckets-and-apps-for-grant-access-to-user-form-1

### Checklist
- [x] Filter out apps/buckets already associated with user