### PR TITLE
`GET /buckets/:id/edit` filters already associated apps/users

### DIFF
--- a/app/buckets/views.js
+++ b/app/buckets/views.js
@@ -87,18 +87,21 @@ exports.bucket_details = [
 exports.bucket_edit = [
   ensureLoggedIn('/login'),
   function(req, res, next) {
-    let bucket_request = api.get_bucket(req.params.id);
-    let apps_request = api.list_apps();
-    let users_request = api.list_users();
+    const bucket_request = api.get_bucket(req.params.id);
+    const apps_request = api.list_apps();
+    const users_request = api.list_users();
 
     Promise
       .all([bucket_request, apps_request, users_request])
       .then((responses) => {
-        let [bucket_response, apps_response, users_response] = responses;
-        let template_args = {
-          bucket: bucket_response,
-          apps: apps_response.results,
-          users: users_response.results,
+        const [bucket, apps_response, users_response] = responses;
+        const all_apps = apps_response.results;
+        const all_users = users_response.results;
+
+        const template_args = {
+          bucket: bucket,
+          apps_options: all_apps,
+          users_options: all_users,
         };
         res.render('buckets/edit.html', template_args);
       })

--- a/app/buckets/views.js
+++ b/app/buckets/views.js
@@ -84,6 +84,19 @@ exports.bucket_details = [
   }
 ];
 
+
+const get_apps_options = (bucket, all_apps) => {
+  const associated_ids = bucket.apps3buckets.map(as => as.app.id);
+
+  return all_apps.filter(app => !associated_ids.includes(app.id));
+};
+
+const get_users_options = (bucket, all_users) => {
+  const associated_ids = bucket.users3buckets.map(us => us.user.auth0_id);
+
+  return all_users.filter(user => !associated_ids.includes(user.auth0_id));
+};
+
 exports.bucket_edit = [
   ensureLoggedIn('/login'),
   function(req, res, next) {
@@ -100,8 +113,8 @@ exports.bucket_edit = [
 
         const template_args = {
           bucket: bucket,
-          apps_options: all_apps,
-          users_options: all_users,
+          apps_options: get_apps_options(bucket, all_apps),
+          users_options: get_users_options(bucket, all_users),
         };
         res.render('buckets/edit.html', template_args);
       })

--- a/app/templates/buckets/edit.html
+++ b/app/templates/buckets/edit.html
@@ -6,8 +6,8 @@
 
 <pre>bucket = {{ bucket | dump(4) | safe }}</pre>
 <br />
-<pre>apps = {{ apps | dump(4) | safe }}</pre>
+<pre>apps_options = {{ apps_options | dump(4) | safe }}</pre>
 <br />
-<pre>users = {{ users | dump(4) | safe }}</pre>
+<pre>users_options = {{ users_options | dump(4) | safe }}</pre>
 
 {% endblock %}

--- a/test/fixtures/bucket.js
+++ b/test/fixtures/bucket.js
@@ -3,6 +3,35 @@ module.exports = {
   "url": "http://localhost:8000/s3buckets/1/",
   "name": "test-bucket-1",
   "arn": "arn:aws:s3:::test-bucket-1",
-  "apps3buckets": [],
+  "apps3buckets": [
+    {
+      "id": 1,
+      "url": "http://localhost:8000/apps3buckets/1/",
+      "app": {
+        "id": 1,
+        "url": "http://localhost:8000/apps/1/",
+        "name": "test-app",
+        "slug": "test-app",
+        "repo_url": "https://www.example.com/test-app",
+        "iam_role_name": "test_app-test-app",
+        "created_by": "github|1"
+      },
+      "access_level": "readonly"
+    }
+  ],
+  "users3buckets": [
+    {
+      "id": 1,
+      "user": {
+        "auth0_id": "github|1",
+        "url": "http://localhost:8000/users/github%7C1/",
+        "username": "johndoe",
+        "name": "",
+        "email": ""
+      },
+      "access_level": "readonly",
+      "is_admin": false
+    }
+  ],
   "created_by": null
 }

--- a/test/fixtures/user.js
+++ b/test/fixtures/user.js
@@ -1,7 +1,7 @@
 module.exports = {
   "auth0_id": "github|1",
   "url": "http://localhost:8000/users/github%7C1/",
-  "username": "xoen",
+  "username": "johndoe",
   "name": "",
   "email": "",
   "groups": [],

--- a/test/fixtures/users.js
+++ b/test/fixtures/users.js
@@ -12,7 +12,7 @@ module.exports = {
       "groups": [],
     },
     {
-      "auth0_id": "github|1",
+      "auth0_id": "github|2",
       "url": "http://localhost:8000/users/" + escape("github|2"),
       "username": "Mario Rossi",
       "name": "Mario Rossi",

--- a/test/test-bucket-edit.js
+++ b/test/test-bucket-edit.js
@@ -45,8 +45,8 @@ describe('Edit bucket form', () => {
           assert(users_list_request.isDone(), 'API call to /users/ expected');
           assert.equal(args.template, 'buckets/edit.html');
           assert.deepEqual(args.context.bucket, bucket);
-          assert.deepEqual(args.context.apps, apps.results);
-          assert.deepEqual(args.context.users, users.results);
+          assert.deepEqual(args.context.apps_options, apps.results);
+          assert.deepEqual(args.context.users_options, users.results);
         });
     });
 

--- a/test/test-bucket-edit.js
+++ b/test/test-bucket-edit.js
@@ -45,8 +45,8 @@ describe('Edit bucket form', () => {
           assert(users_list_request.isDone(), 'API call to /users/ expected');
           assert.equal(args.template, 'buckets/edit.html');
           assert.deepEqual(args.context.bucket, bucket);
-          assert.deepEqual(args.context.apps_options, apps.results);
-          assert.deepEqual(args.context.users_options, users.results);
+          assert.deepEqual(args.context.apps_options, [apps.results[1]]);
+          assert.deepEqual(args.context.users_options, [users.results[1]]);
         });
     });
 


### PR DESCRIPTION
### What 
Similar to what we do in other endpoints

### Why
UI uses the `apps_options`/`users_options` to populate the form but it's only interested in things not already associated with the S3 Bucket.

### Part of ticket

https://trello.com/c/hgdqE4dG/471-cp-api-present-s3bucketusers3buckets-as-in-other-endpoints-4


### Blocked by
(merged now) Backend changes: https://github.com/ministryofjustice/analytics-platform-control-panel/pull/63