### PR TITLE
Show actual buckets on create app page

### DIFF
--- a/app/apps/views.js
+++ b/app/apps/views.js
@@ -7,12 +7,8 @@ var routes = require('../routes');
 exports.new_app = [
   ensureLoggedIn('/login'),
   function (req, res, next) {
-    const buckets_request = api.list_buckets();
-
-    Promise
-      .all([buckets_request])
-      .then(function(response) {
-        const [buckets_response] = response;
+    api.list_buckets()
+      .then((buckets_response) => {
         const template_args = {
           prefix: process.env.ENV + '-',
           buckets: buckets_response.results,
@@ -21,7 +17,6 @@ exports.new_app = [
       })
       .catch(next);
   }
-
 ];
 
 

--- a/app/apps/views.js
+++ b/app/apps/views.js
@@ -5,37 +5,21 @@ var routes = require('../routes');
 
 
 exports.new_app = [
-
   ensureLoggedIn('/login'),
+  function (req, res, next) {
+    const buckets_request = api.list_buckets();
 
-  function (req, res) {
-
-    res.render('apps/new.html', {
-      prefix: process.env.ENV + '-',
-      buckets: [
-        {
-          id: 1,
-          name: 'dev-dummy-bucket1'
-        },
-        {
-          id: 2,
-          name: 'dev-dummy-bucket2'
-        },
-        {
-          id: 3,
-          name: 'dev-dummy-bucket3'
-        },
-        {
-          id: 4,
-          name: 'dev-dummy-bucket4'
-        },
-        {
-          id: 5,
-          name: 'dev-dummy-bucket5'
-        },
-      ]
-    });
-
+    Promise
+      .all([buckets_request])
+      .then(function(response) {
+        const [buckets_response] = response;
+        const template_args = {
+          prefix: process.env.ENV + '-',
+          buckets: buckets_response.results,
+        };
+        res.render('apps/new.html', template_args);
+      })
+      .catch(next);
   }
 
 ];

--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -40,9 +40,9 @@
   <div class="form-group">
 
     <fieldset>
-      <h2 class="heading-medium">Attach a datasource (S3 bucket)</h2>
-      <p>Attach an existing bucket to your app, or create a new bucket. This can also be done later.</p>
-      <p>Additional buckets can also be attached after your app is created.</p>
+      <h2 class="heading-medium">Connect a datasource (S3 bucket)</h2>
+      <p>Connect an existing bucket to your app, or create a new bucket. This can also be done later.</p>
+      <p>Additional buckets can also be connected after your app is created.</p>
       <div class="multiple-choice" data-target="new-app-datasource-create-new-source">
         <input type="radio" id="new-app-datasource-create" name="new-app-datasource" value="create">
         <label for="new-app-datasource-create">Create a new datasource</label>
@@ -55,7 +55,7 @@
 
       <div class="multiple-choice" data-target="new-app-datasource-existing-source">
         <input type="radio" id="new-app-datasource-select" name="new-app-datasource" value="select">
-        <label for="new-app-datasource-select">Attach an existing app data source</label>
+        <label for="new-app-datasource-select">Connect an existing app data source</label>
       </div>
       <div class="panel panel-border-narrow js-hidden" id="new-app-datasource-existing-source">
         <label class="form-label" for="select-existing-datasource">Select app data source</label>


### PR DESCRIPTION
## What

Show actual buckets from API in dropdown instead of dummy data. Was intended as part of a "connect bucket during API creation" PR, but parking that for now.

## How to review

1. check out, run app, log in
2. go to `/apps/new`
3. scroll down and select "Connect an existing data source"
4. check the dropdown which appears – it should contain actual bucket data from your API rather than `dev-dummy-bucket-[1-5]`
