### PR TITLE
Log Redis errors and use password

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -108,7 +108,9 @@ config.session = {
 
 config.session_store = {
   host: 'redis',
-  port: 6379
+  port: 6379,
+  logErrors: true,
+  pass: process.env.REDIS_PASSWORD
 };
 
 config.static = {

--- a/app/config.js
+++ b/app/config.js
@@ -107,7 +107,7 @@ config.session = {
 };
 
 config.session_store = {
-  host: 'redis',
+  host: process.env.REDIS_HOST || 'redis',
   port: 6379,
   logErrors: true,
   pass: process.env.REDIS_PASSWORD

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,5 +47,8 @@ services:
       POSTGRES_DB: "controlpanel"
   redis:
     image: "redis:4.0.2-alpine"
+    env_file:
+      - .env
     ports:
       - "6379:6379"
+    command: ['redis-server', '--requirepass', '$REDIS_PASSWORD']


### PR DESCRIPTION
## What

* Configure Redis to log errors to console
* Use a password for Redis to match deployment

## How to review

1. Run `docker-compose up`
2. See Redis error log message `WARNING: The REDIS_PASSWORD variable is not set. Defaulting to a blank string.` and possibly other error messages.
3. Note that you cannot progress past the login screen.
3. Add a `REDIS_PASSWORD` env var to your `.env` file
4. Re-run `docker-compose up`
5. See no error message from Redis