### PR TITLE
Renamed `app.connect_bucket` endpoint

### DIFF
--- a/app/api-client.js
+++ b/app/api-client.js
@@ -1,41 +1,34 @@
-var log = require('bole')('api-client');
-var config = require('../app/config');
-var request = require('request-promise');
-var url = require('url');
+const config = require('../app/config');
+const request = require('request-promise');
+const url = require('url');
 
 
 module.exports = (function () {
-
   var token = 'invalid token';
 
   function api_request(options) {
     try {
       return request(override_defaults(options));
-
     } catch (error) {
       throw new Error(`API: ${options.method || 'GET'} ${options.endpoint} failed: ${error}`);
     }
   }
 
-
   function override_defaults(options) {
-
-    var defaults = {
+    let defaults = {
       method: 'GET',
       uri: endpoint_url(options.endpoint),
       headers: {
-        'Authorization': jwt_auth(),
+        Authorization: jwt_auth(),
       },
       body: options.resource,
-      json: true
+      json: true,
     };
 
     return Object.assign(defaults, options);
   }
 
-
   function endpoint_url(endpoint) {
-
     if (!endpoint) {
       throw new Error('Missing endpoint');
     }
@@ -47,19 +40,16 @@ module.exports = (function () {
     return url.resolve(config.api.base_url, endpoint);
   }
 
-
   function basic_auth() {
     return 'Basic ' + new Buffer(
       config.api.username + ':' + config.api.password).toString('base64');
   }
 
-
   function jwt_auth() {
-    return 'JWT ' + token;
+    return `JWT ${token}`;
   }
 
-
-  var api = {};
+  let api = {};
 
   api.set_token = function (jwt) {
     token = jwt;
@@ -70,15 +60,15 @@ module.exports = (function () {
   };
 
   api.list_users = function () {
-    return api_request({endpoint: 'users'});
+    return api_request({ endpoint: 'users' });
   };
 
   api.get_user = function (id) {
-    return api_request({endpoint: 'users/' + id});
+    return api_request({ endpoint: `users/${id}` });
   };
 
   api.add_user = function (user) {
-    return api_request({method: 'POST', endpoint: 'users', resource: user});
+    return api_request({ method: 'POST', endpoint: 'users', resource: user });
   };
 
   api.users = {
@@ -88,19 +78,19 @@ module.exports = (function () {
   };
 
   api.list_apps = function () {
-      return api_request({endpoint: 'apps'});
+    return api_request({ endpoint: 'apps' });
   };
 
   api.list_user_apps = function (user_id) {
-    return api_request({endpoint: 'users/' + user_id + '/apps'});
+    return api_request({ endpoint: `users/${user_id}/apps` });
   };
 
   api.get_app = function (id) {
-    return api_request({endpoint: 'apps/' + id});
+    return api_request({ endpoint: `apps/${id}` });
   };
 
   api.add_app = function (app) {
-    return api_request({method: 'POST', endpoint: 'apps/', resource: app});
+    return api_request({ method: 'POST', endpoint: 'apps/', resource: app });
   };
 
   api.apps = {
@@ -110,48 +100,46 @@ module.exports = (function () {
   };
 
   api.list_buckets = function () {
-    return api_request({endpoint: 's3buckets'});
+    return api_request({ endpoint: 's3buckets' });
   };
 
   api.list_app_buckets = function (app_id) {
-    return api_request({endpoint: 'apps/' + app_id + '/s3buckets'});
+    return api_request({ endpoint: `apps/${app_id}/s3buckets` });
   };
 
   api.list_user_buckets = function (user_id) {
-    return api_request({endpoint: 'users/' + user_id + '/s3buckets'});
+    return api_request({ endpoint: `users/${user_id}/s3buckets` });
   };
 
   api.get_bucket = function (id) {
-    return api_request({endpoint: 's3buckets/' + id});
+    return api_request({ endpoint: `s3buckets/${id}` });
   };
 
   api.add_bucket = function (bucket) {
-    return api_request({method: 'POST', endpoint: 's3buckets', resource: bucket});
+    return api_request({ method: 'POST', endpoint: 's3buckets', resource: bucket });
   };
 
-
   api.buckets = {
-    'list': api.list_buckets,
-    'get': api.get_bucket,
-    'add': api.add_bucket,
+    list: api.list_buckets,
+    get: api.get_bucket,
+    add: api.add_bucket,
   };
 
   api.add_apps3bucket = (apps3bucket) => {
-    return api_request({method: 'POST', endpoint: 'apps3buckets', resource: apps3bucket});
+    return api_request({ method: 'POST', endpoint: 'apps3buckets', resource: apps3bucket });
   };
 
   api.apps3buckets = {
     add: api.add_apps3bucket,
-  }
+  };
 
   api.add_users3bucket = (users3bucket) => {
-    return api_request({method: 'POST', endpoint: 'users3buckets', resource: users3bucket});
+    return api_request({ method: 'POST', endpoint: 'users3buckets', resource: users3bucket });
   };
 
   api.users3buckets = {
     add: api.add_users3bucket,
-  }
+  };
 
   return api;
-
 })();

--- a/app/api-client.js
+++ b/app/api-client.js
@@ -103,15 +103,10 @@ module.exports = (function () {
     return api_request({method: 'POST', endpoint: 'apps/', resource: app});
   };
 
-  api.connect_bucket_to_app = function (apps3bucket) {
-    return api_request({method: 'POST', endpoint: 'apps3buckets', resource: apps3bucket});
-  };
-
   api.apps = {
     list: api.list_apps,
     get: api.get_app,
     add: api.add_app,
-    connect_bucket: api.connect_bucket_to_app,
   };
 
   api.list_buckets = function () {
@@ -141,6 +136,13 @@ module.exports = (function () {
     'add': api.add_bucket,
   };
 
+  api.add_apps3bucket = (apps3bucket) => {
+    return api_request({method: 'POST', endpoint: 'apps3buckets', resource: apps3bucket});
+  };
+
+  api.apps3buckets = {
+    add: api.add_apps3bucket,
+  }
 
   api.add_users3bucket = (users3bucket) => {
     return api_request({method: 'POST', endpoint: 'users3buckets', resource: users3bucket});

--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -106,23 +106,3 @@ exports.app_details = [
       .catch(next);
   },
 ];
-
-
-exports.connect_bucket = [
-  ensureLoggedIn('/login'),
-  function(req, res, next) {
-
-    const apps3bucket = {
-      app: req.params.app_id,
-      s3bucket: req.body.connect_bucket,
-      access_level: 'readonly'
-    };
-
-    api.apps.connect_bucket(apps3bucket)
-      .then(function () {
-        res.redirect(routes.url_for('apps.details', {id: apps3bucket.app}));
-      })
-      .catch(next);
-
-  }
-];

--- a/app/apps/routes.js
+++ b/app/apps/routes.js
@@ -5,7 +5,6 @@ module.exports = [
   {name: 'new', pattern: '/apps/new', handler: handlers.new_app},
   {name: 'list', pattern: '/apps', handler: handlers.list_apps},
   {name: 'create', method: 'POST', pattern: '/apps/create', handler: handlers.create_app},
-  {name: 'connect_bucket', method: 'POST', pattern: '/apps/:app_id/connect_bucket', handler: handlers.connect_bucket},
   {name: 'list_user_apps', pattern: '/user/:id/apps', handler: handlers.list_user_apps},
   {name: 'details', pattern: '/apps/:id', handler: handlers.app_details},
 ];

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -1,0 +1,24 @@
+const { ensureLoggedIn } = require('connect-ensure-login');
+
+const api = require('../api-client');
+const routes = require('../routes');
+
+
+exports.create = [
+  ensureLoggedIn('/login'),
+  (req, res, next) => {
+    const { app_id, bucket_id } = req.body;
+
+    const apps3bucket = {
+      app: app_id,
+      s3bucket: bucket_id,
+      access_level: 'readonly',
+    };
+
+    api.apps3buckets.add(apps3bucket)
+      .then(() => {
+        res.redirect(routes.url_for('app.details', { id: app_id }));
+      })
+      .catch(next);
+  },
+];

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -17,7 +17,7 @@ exports.create = [
 
     api.apps3buckets.add(apps3bucket)
       .then(() => {
-        res.redirect(routes.url_for('app.details', { id: app_id }));
+        res.redirect(routes.url_for('apps.details', { id: app_id }));
       })
       .catch(next);
   },

--- a/app/apps3buckets/routes.js
+++ b/app/apps3buckets/routes.js
@@ -1,0 +1,23 @@
+const handlers = require('./handlers');
+
+
+module.exports = [
+  {
+    name: 'create',
+    method: 'POST',
+    pattern: '/apps3buckets',
+    handler: handlers.create,
+  },
+  // {
+  //   name: 'update',
+  //   method: 'POST',
+  //   pattern: '/apps3buckets/:id',
+  //   handler: handlers.update,
+  // },
+  // {
+  //   name: 'destroy',
+  //   method: 'POST',
+  //   pattern: '/apps3buckets/:id/destroy',
+  //   handler: handlers.destroy,
+  // },
+];

--- a/app/config.js
+++ b/app/config.js
@@ -20,6 +20,7 @@ config.apps = [
   'apps',
   'users',
   'buckets',
+  'apps3buckets',
   'users3buckets',
 ];
 

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -72,10 +72,11 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
 {% endif %}
 
 {% if buckets_options.length %}
-  <form action="{{ url_for('apps.connect_bucket', {app_id: app.id}) }}" method="post">
+  <form action="{{ url_for('apps3buckets.create') }}" method="post">
+    <input type="hidden" name="app_id" value="{{ app.id }}" />
     <div class="form-group">
-      <label class="form-label" for="connect_bucket">Connect an app data source</label>
-      <select class="form-control no-blank" id="connect_bucket" name="connect_bucket">
+      <label class="form-label" for="bucket_id">Connect an app data source</label>
+      <select class="form-control no-blank" id="bucket_id" name="bucket_id">
         <option value="">Select app data source</option>
         {% for bucket in buckets_options %}
           <option value="{{ bucket.id }}">{{ bucket.name }}</option>

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require('chai').assert;
+const nock = require('nock');
+
+const config = require('../app/config');
+const handlers = require('../app/apps3buckets/handlers');
+const url_for = require('../app/routes').url_for;
+
+
+describe('Edit bucket form', () => {
+
+  describe('when granting access to user', () => {
+
+    it('make request to API', () => {
+      const bucket_id = 42;
+      const app_id = 123;
+
+      // Mock `POST /apps3buckets` request
+      const post_apps3buckets = nock(config.api.base_url)
+        .post(`/apps3buckets/`, {
+          app: app_id,
+          s3bucket: bucket_id,
+          access_level: "readonly",
+        })
+        .reply(201);
+
+      let request = new Promise((resolve, reject) => {
+        let req = {
+          body: {
+            app_id: app_id,
+            bucket_id: bucket_id,
+          },
+        };
+        let res = {
+          redirect: (redirect_url) => {
+            resolve(redirect_url);
+          }
+        };
+
+        handlers.create[1](req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(post_apps3buckets.isDone(), `Make POST request to /apps3buckets (API)`);
+
+          const expected_redirect_url = url_for('apps.details', {id: app_id});
+          assert.equal(redirect_url, expected_redirect_url);
+        });
+    });
+
+  });
+
+});


### PR DESCRIPTION
### What

This is now `POST /apps3buckets` as in [other PR](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/47)

I also used this opportunity to partially improve the linting situation for the `api-client.js` file.

**NOTE**: This is currently based off the other PR branch, not `master` - I'll change rebase off master as soon as the other is merged.

### Ticket

https://trello.com/c/nvOCtrlY/472-1-rename-appsconnectbucket-appsgrantbucketaccess
