### PR TITLE
Enable access logs by default

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -11,7 +11,7 @@ config.api = {
 };
 
 config.app = {
-  env: process.env.NODE_ENV || 'dev',
+  env: process.env.ENV || 'dev',
   asset_path: '/static/'
 };
 
@@ -47,6 +47,7 @@ config.js = {
 };
 
 config.log = {
+  requests: process.env.ENABLE_ACCESS_LOGS !== 'false',
   stream: process.stdout,
   level: process.env.LOG_LEVEL || 'debug'
 };

--- a/app/middleware/request-logging.js
+++ b/app/middleware/request-logging.js
@@ -1,5 +1,5 @@
 module.exports = (app, conf, log) => {
-  if (conf.app.env !== 'dev') {
+  if (conf.log.ENABLE_ACCESS_LOGS) {
     log.debug('adding request-logging');
     return require('morgan')('combined');
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "passport": "^0.4.0",
     "passport-auth0-openidconnect": "^0.1.0",
     "raven": "^2.2.1",
+    "redis": "^2.8.0",
     "request": "^2.82.0",
     "request-promise": "^4.2.1",
     "request-promise-core": "^1.1.1"


### PR DESCRIPTION
## What

* Enable access logs by default

## How to review

1. `docker-compose up`
2. Browse to http://localhost:3000
3. See request logging
4. Add `ENABLE_ACCESS_LOGS=false` to your `.env` file
5. Restart docker-compose
6. See no request logging
