### PR TITLE
Add endpoints to update/delete apps3buckets

### DIFF
--- a/app/api-client.js
+++ b/app/api-client.js
@@ -129,8 +129,18 @@ module.exports = (function () {
     return api_request({ method: 'POST', endpoint: 'apps3buckets', resource: apps3bucket });
   };
 
+  api.update_apps3bucket = (apps3bucket) => {
+    return api_request({ method: 'PATCH', endpoint: `apps3buckets/${apps3bucket.id}`, resource: apps3bucket });
+  };
+
+  api.delete_apps3bucket = (apps3bucket_id) => {
+    return api_request({ method: 'DELETE', endpoint: `apps3buckets/${apps3bucket_id}` });
+  };
+
   api.apps3buckets = {
     add: api.add_apps3bucket,
+    update: api.update_apps3bucket,
+    delete: api.delete_apps3bucket,
   };
 
   api.add_users3bucket = (users3bucket) => {

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -22,3 +22,33 @@ exports.create = [
       .catch(next);
   },
 ];
+
+exports.update = [
+  ensureLoggedIn('/login'),
+  (req, res, next) => {
+    const apps3bucket_id = req.params.id;
+    const { access_level, redirect_to } = req.body;
+
+    const apps3bucket = {
+      id: apps3bucket_id,
+      access_level: access_level,
+    };
+
+    api.apps3buckets.update(apps3bucket)
+      .then(() => {
+        res.redirect(redirect_to);
+      })
+      .catch(next);
+  },
+];
+
+exports.delete = [
+  ensureLoggedIn('/login'),
+  (req, res, next) => {
+    api.apps3buckets.delete(req.params.id)
+      .then(() => {
+        res.redirect(req.body.redirect_to);
+      })
+      .catch(next);
+  },
+];

--- a/app/apps3buckets/routes.js
+++ b/app/apps3buckets/routes.js
@@ -8,16 +8,16 @@ module.exports = [
     pattern: '/apps3buckets',
     handler: handlers.create,
   },
-  // {
-  //   name: 'update',
-  //   method: 'POST',
-  //   pattern: '/apps3buckets/:id',
-  //   handler: handlers.update,
-  // },
-  // {
-  //   name: 'destroy',
-  //   method: 'POST',
-  //   pattern: '/apps3buckets/:id/destroy',
-  //   handler: handlers.destroy,
-  // },
+  {
+    name: 'update',
+    method: 'POST',
+    pattern: '/apps3buckets/:id',
+    handler: handlers.update,
+  },
+  {
+    name: 'delete',
+    method: 'POST',
+    pattern: '/apps3buckets/:id/delete',
+    handler: handlers.delete,
+  },
 ];

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -55,13 +55,26 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
       </tr>
     </thead>
     <tbody>
-      {% for bucket in app.apps3buckets %}
+      {% for apps3bucket in app.apps3buckets %}
         <tr>
-          <td><a href="{{ url_for('buckets.details', {id: bucket.s3bucket.id}) }}">{{ bucket.s3bucket.name }}</a></td>
-          <td>{% if bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
+          <td><a href="{{ url_for('buckets.details', {id: apps3bucket.s3bucket.id}) }}">{{ apps3bucket.s3bucket.name }}</a></td>
+          <td>{% if apps3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
           <td class="align-right">
-            <a href="#" class="button button-secondary">{% if bucket.access_level == 'readwrite' %}Remove{% else %}Grant{% endif %} read/write access</a>
-            <a href="#" class="button button-secondary">Remove app access</a>
+            <!-- Button to change access level -->
+            <form action="{{ url_for('apps3buckets.update', {id: apps3bucket.id}) }}" method="post">
+              <input type="hidden" name="access_level" value="{% if apps3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}">
+
+              <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
+
+              <input type="submit" class="button button-secondary js-confirm" value="{% if apps3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+            </form>
+
+            <!-- Button to revoke access -->
+            <form action="{{ url_for('apps3buckets.delete', {id: apps3bucket.id}) }}" method="post">
+              <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
+
+              <input type="submit" class="button button-secondary js-confirm" value="Remove app access" />
+            </form>
           </td>
         </tr>
       {% endfor %}

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -1,41 +1,34 @@
-"use strict";
-
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const nock = require('nock');
 
 const config = require('../app/config');
 const handlers = require('../app/apps3buckets/handlers');
-const url_for = require('../app/routes').url_for;
+const { url_for } = require('../app/routes');
 
 
 describe('Edit bucket form', () => {
-
   describe('when granting access to user', () => {
-
     it('make request to API', () => {
       const bucket_id = 42;
       const app_id = 123;
 
       // Mock `POST /apps3buckets` request
       const post_apps3buckets = nock(config.api.base_url)
-        .post(`/apps3buckets/`, {
+        .post('/apps3buckets/', {
           app: app_id,
           s3bucket: bucket_id,
-          access_level: "readonly",
+          access_level: 'readonly',
         })
         .reply(201);
 
-      let request = new Promise((resolve, reject) => {
-        let req = {
-          body: {
-            app_id: app_id,
-            bucket_id: bucket_id,
-          },
+      const request = new Promise((resolve, reject) => {
+        const req = {
+          body: { app_id, bucket_id },
         };
-        let res = {
+        const res = {
           redirect: (redirect_url) => {
             resolve(redirect_url);
-          }
+          },
         };
 
         handlers.create[1](req, res, reject);
@@ -43,13 +36,11 @@ describe('Edit bucket form', () => {
 
       return request
         .then((redirect_url) => {
-          assert(post_apps3buckets.isDone(), `Make POST request to /apps3buckets (API)`);
+          assert(post_apps3buckets.isDone(), 'Make POST request to /apps3buckets (API)');
 
-          const expected_redirect_url = url_for('apps.details', {id: app_id});
+          const expected_redirect_url = url_for('apps.details', { id: app_id });
           assert.equal(redirect_url, expected_redirect_url);
         });
     });
-
   });
-
 });

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -12,7 +12,6 @@ describe('Edit bucket form', () => {
       const bucket_id = 42;
       const app_id = 123;
 
-      // Mock `POST /apps3buckets` request
       const post_apps3buckets = nock(config.api.base_url)
         .post('/apps3buckets/', {
           app: app_id,
@@ -36,7 +35,7 @@ describe('Edit bucket form', () => {
 
       return request
         .then((redirect_url) => {
-          assert(post_apps3buckets.isDone(), 'Make POST request to /apps3buckets (API)');
+          assert(post_apps3buckets.isDone(), 'Did not make POST request to API endpoint /apps3buckets/ as expected');
 
           const expected_redirect_url = url_for('apps.details', { id: app_id });
           assert.equal(redirect_url, expected_redirect_url);

--- a/test/test-apps3buckets-delete.js
+++ b/test/test-apps3buckets-delete.js
@@ -1,17 +1,12 @@
-"use strict";
-
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const nock = require('nock');
 
 const config = require('../app/config');
 const handlers = require('../app/apps3buckets/handlers');
-const url_for = require('../app/routes').url_for;
 
 
 describe('Edit bucket form', () => {
-
   describe('when revoking access to user', () => {
-
     it('make request to API', () => {
       const apps3bucket_id = 42;
       const redirect_to = 'apps/123';
@@ -21,15 +16,15 @@ describe('Edit bucket form', () => {
         .delete(`/apps3buckets/${apps3bucket_id}/`)
         .reply(204);
 
-      let request = new Promise((resolve, reject) => {
-        let req = {
+      const request = new Promise((resolve, reject) => {
+        const req = {
           params: { id: apps3bucket_id },
-          body: { redirect_to: redirect_to},
+          body: { redirect_to },
         };
-        let res = {
+        const res = {
           redirect: (redirect_url) => {
             resolve(redirect_url);
-          }
+          },
         };
 
         handlers.delete[1](req, res, reject);
@@ -41,7 +36,5 @@ describe('Edit bucket form', () => {
           assert.equal(redirect_url, redirect_to);
         });
     });
-
   });
-
 });

--- a/test/test-apps3buckets-delete.js
+++ b/test/test-apps3buckets-delete.js
@@ -1,0 +1,47 @@
+"use strict";
+
+const assert = require('chai').assert;
+const nock = require('nock');
+
+const config = require('../app/config');
+const handlers = require('../app/apps3buckets/handlers');
+const url_for = require('../app/routes').url_for;
+
+
+describe('Edit bucket form', () => {
+
+  describe('when revoking access to user', () => {
+
+    it('make request to API', () => {
+      const apps3bucket_id = 42;
+      const redirect_to = 'apps/123';
+
+      // Mock `DELETE /apps3buckets/:id` request
+      const delete_apps3buckets = nock(config.api.base_url)
+        .delete(`/apps3buckets/${apps3bucket_id}/`)
+        .reply(204);
+
+      let request = new Promise((resolve, reject) => {
+        let req = {
+          params: { id: apps3bucket_id },
+          body: { redirect_to: redirect_to},
+        };
+        let res = {
+          redirect: (redirect_url) => {
+            resolve(redirect_url);
+          }
+        };
+
+        handlers.delete[1](req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(delete_apps3buckets.isDone(), `Make DELETE request to /apps3buckets/${apps3bucket_id} (API)`);
+          assert.equal(redirect_url, redirect_to);
+        });
+    });
+
+  });
+
+});

--- a/test/test-apps3buckets-delete.js
+++ b/test/test-apps3buckets-delete.js
@@ -11,7 +11,6 @@ describe('Edit bucket form', () => {
       const apps3bucket_id = 42;
       const redirect_to = 'apps/123';
 
-      // Mock `DELETE /apps3buckets/:id` request
       const delete_apps3buckets = nock(config.api.base_url)
         .delete(`/apps3buckets/${apps3bucket_id}/`)
         .reply(204);
@@ -32,7 +31,7 @@ describe('Edit bucket form', () => {
 
       return request
         .then((redirect_url) => {
-          assert(delete_apps3buckets.isDone(), `Make DELETE request to /apps3buckets/${apps3bucket_id} (API)`);
+          assert(delete_apps3buckets.isDone(), `Did't make DELETE request to API endpoint to /apps3buckets/${apps3bucket_id}/`);
           assert.equal(redirect_url, redirect_to);
         });
     });

--- a/test/test-apps3buckets-update.js
+++ b/test/test-apps3buckets-update.js
@@ -12,7 +12,6 @@ describe('Edit bucket form', () => {
       const access_level = 'readonly';
       const redirect_to = 'apps/123';
 
-      // Mock `POST /apps3buckets` request
       const patch_apps3buckets = nock(config.api.base_url)
         .patch(`/apps3buckets/${apps3bucket_id}/`, {
           id: apps3bucket_id,
@@ -36,7 +35,7 @@ describe('Edit bucket form', () => {
 
       return request
         .then((redirect_url) => {
-          assert(patch_apps3buckets.isDone(), `Make PATCH request to /apps3buckets/${apps3bucket_id} (API)`);
+          assert(patch_apps3buckets.isDone(), `Didn't make PATCH request to API endpoint /apps3buckets/${apps3bucket_id}/ as expected`);
 
           assert.equal(redirect_url, redirect_to);
         });

--- a/test/test-apps3buckets-update.js
+++ b/test/test-apps3buckets-update.js
@@ -1,0 +1,45 @@
+const { assert } = require('chai');
+const nock = require('nock');
+
+const config = require('../app/config');
+const handlers = require('../app/apps3buckets/handlers');
+
+
+describe('Edit bucket form', () => {
+  describe('when updating user access', () => {
+    it('make request to API', () => {
+      const apps3bucket_id = 42;
+      const access_level = 'readonly';
+      const redirect_to = 'apps/123';
+
+      // Mock `POST /apps3buckets` request
+      const patch_apps3buckets = nock(config.api.base_url)
+        .patch(`/apps3buckets/${apps3bucket_id}/`, {
+          id: apps3bucket_id,
+          access_level: access_level,
+        })
+        .reply(201);
+
+      const request = new Promise((resolve, reject) => {
+        const req = {
+          params: { id: apps3bucket_id },
+          body: { access_level, redirect_to },
+        };
+        const res = {
+          redirect: (redirect_url) => {
+            resolve(redirect_url);
+          },
+        };
+
+        handlers.update[1](req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(patch_apps3buckets.isDone(), `Make PATCH request to /apps3buckets/${apps3bucket_id} (API)`);
+
+          assert.equal(redirect_url, redirect_to);
+        });
+    });
+  });
+});

--- a/test/test-users3buckets-create.js
+++ b/test/test-users3buckets-create.js
@@ -16,7 +16,6 @@ describe('Edit bucket form', () => {
       const bucket_id = 42;
       const user_id = 'github|123';
 
-      // Mock `POST /users3buckets` request
       const post_users3buckets = nock(config.api.base_url)
         .post(`/users3buckets/`, {
           user: user_id,
@@ -44,7 +43,7 @@ describe('Edit bucket form', () => {
 
       return request
         .then((redirect_url) => {
-          assert(post_users3buckets.isDone(), `Make POST request to /users3buckets (API)`);
+          assert(post_users3buckets.isDone(), 'Did not make POST request to API endpoint /users3buckets/ as expected');
 
           const expected_redirect_url = url_for('buckets.details', {id: bucket_id});
           assert.equal(redirect_url, expected_redirect_url);


### PR DESCRIPTION
### What
Endpoints:
- `POST /apps3buckets/:id` to update access level
- `POST /apps3buckets/:id/delete` to revoke access

I also updated the template to replace the anchors with forms
(*need* styling from Clive).

Manually tested locally, I'll add some automated tests.

### Why `POST`?
It's only safe to use `POST` and `GET` as form methods in the browsers.
As these requests have a side effects we need to use `POST`.

### Why to pass `redirect_to`?
As this requests could be made from both the `apps.detail` page or the `buckets.details` page we need to know where to redirect the user on success.
Instead of guessing I'm being explicit and just passing this in the form (where I have this information).

### Ticket

https://trello.com/c/yYFb0Tax/475-2-add-endpoint-to-update-app-access-level-to-bucket

- [x] Add tests