### PR TITLE
Add endpoints to update/revoke user access to buckets

### DIFF
--- a/app/api-client.js
+++ b/app/api-client.js
@@ -147,8 +147,18 @@ module.exports = (function () {
     return api_request({ method: 'POST', endpoint: 'users3buckets', resource: users3bucket });
   };
 
+  api.update_users3bucket = (users3bucket) => {
+    return api_request({ method: 'PATCH', endpoint: `users3buckets/${users3bucket.id}`, resource: users3bucket });
+  };
+
+  api.delete_users3bucket = (users3bucket_id) => {
+    return api_request({ method: 'DELETE', endpoint: `users3buckets/${users3bucket_id}` });
+  };
+
   api.users3buckets = {
     add: api.add_users3bucket,
+    update: api.update_users3bucket,
+    delete: api.delete_users3bucket,
   };
 
   return api;

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -73,7 +73,7 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
             <form action="{{ url_for('apps3buckets.delete', {id: apps3bucket.id}) }}" method="post">
               <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
 
-              <input type="submit" class="button button-secondary js-confirm" value="Remove app access" />
+              <input type="submit" class="button button-warning js-confirm" value="Remove app access" />
             </form>
           </td>
         </tr>

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -61,19 +61,19 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
           <td>{% if apps3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
           <td class="align-right">
             <!-- Button to change access level -->
-            <form action="{{ url_for('apps3buckets.update', {id: apps3bucket.id}) }}" method="post">
+            <form action="{{ url_for('apps3buckets.update', {id: apps3bucket.id}) }}" method="post" class="inline-form clearfix">
               <input type="hidden" name="access_level" value="{% if apps3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}">
 
               <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
 
-              <input type="submit" class="button button-secondary js-confirm" value="{% if apps3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+              <input type="submit" class="js-confirm button button-secondary right" value="{% if apps3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
             </form>
 
             <!-- Button to revoke access -->
-            <form action="{{ url_for('apps3buckets.delete', {id: apps3bucket.id}) }}" method="post">
+            <form action="{{ url_for('apps3buckets.delete', {id: apps3bucket.id}) }}" method="post" class="inline-form clearfix">
               <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
 
-              <input type="submit" class="button button-warning js-confirm" value="Remove app access" />
+              <input type="submit" class="js-confirm button button-warning right" value="Revoke access" />
             </form>
           </td>
         </tr>
@@ -97,7 +97,7 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
       </select>
     </div>
     <div class="form-group">
-      <input type="submit" class="button button-secondary" value="Add">
+      <input type="submit" class="button button-secondary" value="Grant access">
     </div>
   </form>
 {% else %}

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -25,8 +25,21 @@
           <td><a href="{{ url_for('users.details', {id: users3bucket.user.auth0_id}) }}">{{ users3bucket.user.username }}</a></td>
           <td>{% if users3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
           <td class="align-right">
-            <a href="#" class="button button-secondary">{% if users3bucket.access_level == 'readwrite' %}Remove{% else %}Grant{% endif %} read/write access</a>
-            <a href="#" class="button button-secondary">Revoke user access</a>
+            <!-- Button to change access level -->
+            <form action="{{ url_for('users3buckets.update', {id: users3bucket.id}) }}" method="post">
+              <input type="hidden" name="access_level" value="{% if users3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}" />
+
+              <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}" />
+
+              <input type="submit" class="button button-secondary js-confirm" value="{% if users3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+            </form>
+
+            <!-- Button to revoke access -->
+            <form action="{{ url_for('users3buckets.delete', {id: users3bucket.id}) }}" method="post">
+              <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}">
+
+              <input type="submit" class="button button-warning js-confirm" value="Revoke user access" />
+            </form>
           </td>
         </tr>
       {% endfor %}

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -26,19 +26,19 @@
           <td>{% if users3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
           <td class="align-right">
             <!-- Button to change access level -->
-            <form action="{{ url_for('users3buckets.update', {id: users3bucket.id}) }}" method="post">
+            <form action="{{ url_for('users3buckets.update', {id: users3bucket.id}) }}" method="post" class="inline-form clearfix">
               <input type="hidden" name="access_level" value="{% if users3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}" />
 
               <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}" />
 
-              <input type="submit" class="button button-secondary js-confirm" value="{% if users3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+              <input type="submit" class="js-confirm button button-secondary" value="{% if users3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
             </form>
 
             <!-- Button to revoke access -->
-            <form action="{{ url_for('users3buckets.delete', {id: users3bucket.id}) }}" method="post">
+            <form action="{{ url_for('users3buckets.delete', {id: users3bucket.id}) }}" method="post" class="inline-form clearfix">
               <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}">
 
-              <input type="submit" class="button button-warning js-confirm" value="Revoke user access" />
+              <input type="submit" class="js-confirm button button-warning" value="Revoke access" />
             </form>
           </td>
         </tr>

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -23,3 +23,33 @@ exports.create = [
       .catch(next);
   },
 ];
+
+exports.update = [
+  ensureLoggedIn('/login'),
+  (req, res, next) => {
+    const users3bucket_id = req.params.id;
+    const { access_level, redirect_to } = req.body;
+
+    const users3bucket = {
+      id: users3bucket_id,
+      access_level: access_level,
+    };
+
+    api.users3buckets.update(users3bucket)
+      .then(() => {
+        res.redirect(redirect_to);
+      })
+      .catch(next);
+  },
+];
+
+exports.delete = [
+  ensureLoggedIn('/login'),
+  (req, res, next) => {
+    api.users3buckets.delete(req.params.id)
+      .then(() => {
+        res.redirect(req.body.redirect_to);
+      })
+      .catch(next);
+  },
+];

--- a/app/users3buckets/routes.js
+++ b/app/users3buckets/routes.js
@@ -8,16 +8,16 @@ module.exports = [
     pattern: '/users3buckets',
     handler: handlers.create,
   },
-  // {
-  //   name: 'update',
-  //   method: 'POST',
-  //   pattern: '/users3buckets/:id',
-  //   handler: handlers.update,
-  // },
-  // {
-  //   name: 'destroy',
-  //   method: 'POST',
-  //   pattern: '/users3buckets/:id/destroy',
-  //   handler: handlers.destroy,
-  // },
+  {
+    name: 'update',
+    method: 'POST',
+    pattern: '/users3buckets/:id',
+    handler: handlers.update,
+  },
+  {
+    name: 'delete',
+    method: 'POST',
+    pattern: '/users3buckets/:id/delete',
+    handler: handlers.delete,
+  },
 ];

--- a/test/test-users3buckets-delete.js
+++ b/test/test-users3buckets-delete.js
@@ -1,0 +1,39 @@
+const { assert } = require('chai');
+const nock = require('nock');
+
+const config = require('../app/config');
+const handlers = require('../app/users3buckets/handlers');
+
+
+describe('Edit bucket form', () => {
+  describe('when revoking access to user', () => {
+    it('make request to API', () => {
+      const users3bucket_id = 42;
+      const redirect_to = 'users/github|123';
+
+      const delete_users3buckets = nock(config.api.base_url)
+        .delete(`/users3buckets/${users3bucket_id}/`)
+        .reply(204);
+
+      const request = new Promise((resolve, reject) => {
+        const req = {
+          params: { id: users3bucket_id },
+          body: { redirect_to },
+        };
+        const res = {
+          redirect: (redirect_url) => {
+            resolve(redirect_url);
+          },
+        };
+
+        handlers.delete[1](req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(delete_users3buckets.isDone(), `Did't make DELETE request to API endpoint to /users3buckets/${users3bucket_id}/`);
+          assert.equal(redirect_url, redirect_to);
+        });
+    });
+  });
+});

--- a/test/test-users3buckets-update.js
+++ b/test/test-users3buckets-update.js
@@ -1,0 +1,44 @@
+const { assert } = require('chai');
+const nock = require('nock');
+
+const config = require('../app/config');
+const handlers = require('../app/users3buckets/handlers');
+
+
+describe('Edit bucket form', () => {
+  describe('when updating user access', () => {
+    it('make request to API', () => {
+      const users3bucket_id = 42;
+      const access_level = 'readonly';
+      const redirect_to = 'buckets/123';
+
+      const patch_users3buckets = nock(config.api.base_url)
+        .patch(`/users3buckets/${users3bucket_id}/`, {
+          id: users3bucket_id,
+          access_level: access_level,
+        })
+        .reply(201);
+
+      const request = new Promise((resolve, reject) => {
+        const req = {
+          params: { id: users3bucket_id },
+          body: { access_level, redirect_to },
+        };
+        const res = {
+          redirect: (redirect_url) => {
+            resolve(redirect_url);
+          },
+        };
+
+        handlers.update[1](req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(patch_users3buckets.isDone(), `Didn't make PATCH request to API endpoint /users3buckets/${users3bucket_id}/ as expected`);
+
+          assert.equal(redirect_url, redirect_to);
+        });
+    });
+  });
+});


### PR DESCRIPTION
### What
- `POST /users3bucketd/:id` to update access level
- `POST /users3bucketd/:id/delete` to revoke access

Also updated template buttons accordingly.

### Why
Because these are required in order to allow users to change access level to S3 buckets and revoke it altogether if necessary.

This is very similar to PR #56 

### Ticket

https://trello.com/c/3TV630wS/478-4-add-endpoints-to-update-revoke-user-access-to-bucket

### TODO
- [x] Write tests
- [x] (Probably) start to use Clive's new (?) button classes