### PR TITLE
Add `yes_no` template macro/helper function

### DIFF
--- a/app/middleware/template-locals.js
+++ b/app/middleware/template-locals.js
@@ -1,3 +1,19 @@
+/*
+Examples:
+
+ - yes_no(is_admin) // => 'Yes' / 'No'
+ - yes_no(access_level, 'readwrite') // => 'Yes' / 'No'
+ - yes_no(is_admin, true, '(Admin)', '') // => '(Admin)' / ''
+ - yes_no(access, 'readwrite', 'Revoke', 'Grant') // => 'Revoke' / 'Grant'
+*/
+function yes_no(value, true_value=true, yes_str='Yes', no_str='No') {
+  if (value === true_value) {
+    return yes_str;
+  } else {
+    return no_str;
+  }
+}
+
 module.exports = (app, conf, log) => {
   log.info('adding template-locals');
   return (req, res, next) => {
@@ -5,6 +21,7 @@ module.exports = (app, conf, log) => {
     app.locals.current_user = req.user || null;
     app.locals.env = process.env;
     app.locals.req = req;
+    app.locals.yes_no = yes_no;
     next();
   };
 };

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -58,15 +58,16 @@ TODO: provide form to add users – also dependent on the above work from @jmoz
       {% for apps3bucket in app.apps3buckets %}
         <tr>
           <td><a href="{{ url_for('buckets.details', {id: apps3bucket.s3bucket.id}) }}">{{ apps3bucket.s3bucket.name }}</a></td>
-          <td>{% if apps3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
+          <td>{{ yes_no(apps3bucket.access_level, 'readwrite') }}</td>
           <td class="align-right">
             <!-- Button to change access level -->
             <form action="{{ url_for('apps3buckets.update', {id: apps3bucket.id}) }}" method="post" class="inline-form clearfix">
-              <input type="hidden" name="access_level" value="{% if apps3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}">
+              <input type="hidden" name="access_level" value="{{ yes_no(apps3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}">
 
               <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
 
-              <input type="submit" class="js-confirm button button-secondary right" value="{% if apps3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+              <input type="submit" class="js-confirm button button-secondary right" value="{{
+yes_no(apps3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} read/write access" />
             </form>
 
             <!-- Button to revoke access -->

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -23,15 +23,15 @@
       {% for users3bucket in bucket.users3buckets %}
         <tr>
           <td><a href="{{ url_for('users.details', {id: users3bucket.user.auth0_id}) }}">{{ users3bucket.user.username }}</a></td>
-          <td>{% if users3bucket.access_level == 'readwrite' %}Yes{% else %}No{% endif %}</td>
+          <td>{{ yes_no(users3bucket.access_level, 'readwrite') }}</td>
           <td class="align-right">
             <!-- Button to change access level -->
             <form action="{{ url_for('users3buckets.update', {id: users3bucket.id}) }}" method="post" class="inline-form clearfix">
-              <input type="hidden" name="access_level" value="{% if users3bucket.access_level == 'readwrite' %}readonly{% else %}readwrite{% endif %}" />
+              <input type="hidden" name="access_level" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}" />
 
               <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}" />
 
-              <input type="submit" class="js-confirm button button-secondary" value="{% if users3bucket.access_level == 'readwrite' %}Revoke{% else %}Grant{% endif %} read/write access" />
+              <input type="submit" class="js-confirm button button-secondary" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} read/write access" />
             </form>
 
             <!-- Button to revoke access -->


### PR DESCRIPTION
### What

This helps simplify repetitive if/else blocks in the template.

The function by default returns 'Yes' if the passed value is
true or 'No' if it's false.

### Examples

This is useful in the simple cases like when listing which users are
admin of an S3 bucket, e.g.

    <td>{{ yes_no(users3bucket.is_admin) }}</td>

The function behaviour can be customised to check if the value is equal
to something else, e.g. a string.

This is useful when displaying 'Yes'/'No' depending on the access level
for example:

    <th>Has R/W access?</th>
    <td>{{ yes_no(users3bucket.access_level, 'readwrite') }}</td>

(In the example above the function will compare access level with 'readwrite'
which is considered the "true" value)

The strings returned can be customised so for example you can use the helper
to display something else, e.g.

    <td>{{ yes_no(users3bucket.is_admin, true, '(Admin)', '') }}</td>

Because these strings can be customised, the helper can be used to "toggle"
the access level value, e.g.

    <inpyt type="hidden" name="access_level" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}" />
    <input type="submit" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} R/W access" />
