### PR TITLE
Add ensure-login middleware

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,6 @@ module.exports = {
   "extends": "airbnb-base",
   "rules": {
     "camelcase": ["off"],
+    "no-use-before-define": ["error", { "classes": false }],
   }
 };

--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -1,80 +1,70 @@
 const { App, Bucket, User } = require('../models');
 
 
-exports.new = [
-  (req, res, next) => {
-    Bucket.list()
-      .then((buckets) => {
-        res.render('apps/new.html', {
-          prefix: `${process.env.ENV}-`,
-          buckets,
-        });
-      })
-      .catch(next);
-  },
-];
-
-
-exports.create = [
-  (req, res, next) => {
-    const app = new App({
-      name: req.body.name,
-      description: req.body.description,
-      repo_url: req.body.repo_url,
-      userapps: [],
-    });
-
-    app.create()
-      .then((new_app) => {
-        const { url_for } = require('../routes'); // eslint-disable-line global-require
-        res.redirect(url_for('apps.details', { id: new_app.id }));
-      })
-      .catch((err) => {
-        if (err.statusCode === 400) {
-          res.render('apps/new.html', {
-            app,
-            errors: err.error,
-          });
-        } else {
-          next(err);
-        }
+exports.new = (req, res, next) => {
+  Bucket.list()
+    .then((buckets) => {
+      res.render('apps/new.html', {
+        prefix: `${process.env.ENV}-`,
+        buckets,
       });
-  },
-];
-
-exports.list = [
-  (req, res, next) => {
-    App.list()
-      .then((apps) => {
-        res.render('apps/list.html', { apps });
-      })
-      .catch(next);
-  },
-];
+    })
+    .catch(next);
+};
 
 
-exports.details = [
-  (req, res, next) => {
-    Promise.all([App.get(req.params.id), Bucket.list(), User.list()])
-      .then(([app, buckets, users]) => {
-        res.render('apps/details.html', {
+exports.create = (req, res, next) => {
+  const app = new App({
+    name: req.body.name,
+    description: req.body.description,
+    repo_url: req.body.repo_url,
+    userapps: [],
+  });
+
+  app.create()
+    .then((new_app) => {
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
+      res.redirect(url_for('apps.details', { id: new_app.id }));
+    })
+    .catch((err) => {
+      if (err.statusCode === 400) {
+        res.render('apps/new.html', {
           app,
-          buckets_options: buckets.exclude(app.buckets),
-          users,
+          errors: err.error,
         });
-      })
-      .catch(next);
-  },
-];
+      } else {
+        next(err);
+      }
+    });
+};
+
+exports.list = (req, res, next) => {
+  App.list()
+    .then((apps) => {
+      res.render('apps/list.html', { apps });
+    })
+    .catch(next);
+};
 
 
-exports.delete = [
-  (req, res, next) => {
-    App.delete(req.params.id)
-      .then(() => {
-        const { url_for } = require('../routes'); // eslint-disable-line global-require
-        res.redirect(url_for('apps.list'));
-      })
-      .catch(next);
-  },
-];
+exports.details = (req, res, next) => {
+  Promise.all([App.get(req.params.id), Bucket.list(), User.list()])
+    .then(([app, buckets, users]) => {
+      res.render('apps/details.html', {
+        app,
+        buckets_options: buckets.exclude(app.buckets),
+        users,
+      });
+    })
+    .catch(next);
+};
+
+
+exports.delete = (req, res, next) => {
+  App.delete(req.params.id)
+    .then(() => {
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
+      res.redirect(url_for('apps.list'));
+    })
+    .catch(next);
+};

--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -1,9 +1,7 @@
-const { ensureLoggedIn } = require('connect-ensure-login');
 const { App, Bucket, User } = require('../models');
 
 
 exports.new = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     Bucket.list()
       .then((buckets) => {
@@ -18,7 +16,6 @@ exports.new = [
 
 
 exports.create = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     const app = new App({
       name: req.body.name,
@@ -46,7 +43,6 @@ exports.create = [
 ];
 
 exports.list = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     App.list()
       .then((apps) => {
@@ -58,7 +54,6 @@ exports.list = [
 
 
 exports.details = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     Promise.all([App.get(req.params.id), Bucket.list(), User.list()])
       .then(([app, buckets, users]) => {
@@ -74,7 +69,6 @@ exports.details = [
 
 
 exports.delete = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     App.delete(req.params.id)
       .then(() => {

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -1,9 +1,7 @@
-const { ensureLoggedIn } = require('connect-ensure-login');
 const { App, AppS3Bucket } = require('../models');
 
 
 exports.create = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     const { app_id, bucket_id } = req.body;
 
@@ -20,7 +18,6 @@ exports.create = [
 ];
 
 exports.update = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     const { access_level, redirect_to } = req.body;
 
@@ -37,7 +34,6 @@ exports.update = [
 ];
 
 exports.delete = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     AppS3Bucket.delete(req.params.id)
       .then(() => { res.redirect(req.body.redirect_to); })

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -1,42 +1,36 @@
 const { App, AppS3Bucket } = require('../models');
 
 
-exports.create = [
-  (req, res, next) => {
-    const { app_id, bucket_id } = req.body;
+exports.create = (req, res, next) => {
+  const { app_id, bucket_id } = req.body;
 
-    App.get(app_id)
-      .then((app) => {
-        return app.grant_bucket_access(bucket_id, 'readonly');
-      })
-      .then((_) => {
-        const { url_for } = require('../routes');
-        res.redirect(url_for('apps.details', { id: app_id }));
-      })
-      .catch(next);
-  },
-];
-
-exports.update = [
-  (req, res, next) => {
-    const { access_level, redirect_to } = req.body;
-
-    new AppS3Bucket({
-      id: req.params.id,
-      access_level: access_level
+  App.get(app_id)
+    .then((app) => {
+      return app.grant_bucket_access(bucket_id, 'readonly');
     })
-      .update()
-      .then((_) => {
-        res.redirect(redirect_to);
-      })
-      .catch(next);
-  },
-];
+    .then((_) => {
+      const { url_for } = require('../routes');
+      res.redirect(url_for('apps.details', { id: app_id }));
+    })
+    .catch(next);
+};
 
-exports.delete = [
-  (req, res, next) => {
-    AppS3Bucket.delete(req.params.id)
-      .then(() => { res.redirect(req.body.redirect_to); })
-      .catch(next);
-  },
-];
+exports.update = (req, res, next) => {
+  const { access_level, redirect_to } = req.body;
+
+  new AppS3Bucket({
+    id: req.params.id,
+    access_level: access_level
+  })
+    .update()
+    .then((_) => {
+      res.redirect(redirect_to);
+    })
+    .catch(next);
+};
+
+exports.delete = (req, res, next) => {
+  AppS3Bucket.delete(req.params.id)
+    .then(() => { res.redirect(req.body.redirect_to); })
+    .catch(next);
+};

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -5,11 +5,9 @@ exports.create = (req, res, next) => {
   const { app_id, bucket_id } = req.body;
 
   App.get(app_id)
-    .then((app) => {
-      return app.grant_bucket_access(bucket_id, 'readonly');
-    })
-    .then((_) => {
-      const { url_for } = require('../routes');
+    .then(app => app.grant_bucket_access(bucket_id, 'readonly'))
+    .then(() => {
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
       res.redirect(url_for('apps.details', { id: app_id }));
     })
     .catch(next);
@@ -20,10 +18,10 @@ exports.update = (req, res, next) => {
 
   new AppS3Bucket({
     id: req.params.id,
-    access_level: access_level
+    access_level,
   })
     .update()
-    .then((_) => {
+    .then(() => {
       res.redirect(redirect_to);
     })
     .catch(next);

--- a/app/base-model.js
+++ b/app/base-model.js
@@ -14,6 +14,26 @@ const model_proxy = {
 };
 
 
+class ModelSet extends Array {
+  constructor(ModelConstructor, data = []) {
+    super(...data.map(obj => new ModelConstructor(obj)));
+    this.model = ModelConstructor;
+  }
+
+  exclude(other) {
+    let others = other;
+    if (other instanceof this.model) {
+      others = [other];
+    }
+
+    const pks = others.map(instance => instance[this.model.pk]);
+
+    return this.filter(instance => !pks.includes(instance[this.model.pk]));
+  }
+}
+
+
+exports.ModelSet = ModelSet;
 class Model {
   constructor(data) {
     this.data = data;
@@ -69,24 +89,3 @@ class Model {
 }
 
 exports.Model = Model;
-
-
-class ModelSet extends Array {
-  constructor(Model, data = []) {
-    super(...data.map(obj => new Model(obj)));
-    this.model = Model;
-  }
-
-  exclude(other) {
-    let others = other;
-    if (other instanceof this.model) {
-      others = [other];
-    }
-
-    const pks = others.map(instance => instance[this.model.pk]);
-
-    return this.filter(instance => !pks.includes(instance[this.model.pk]));
-  }
-}
-
-exports.ModelSet = ModelSet;

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -2,13 +2,11 @@ const { api } = require('../api-client');
 const { User } = require('../models');
 const config = require('../config');
 const passport = require('passport');
-const ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn;
 const raven = require('raven');
 const routes = require('../routes');
 
 
 exports.home = [
-  ensureLoggedIn('/login'),
   function (req, res, next) {
     res.render('home.html');
   }

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -6,11 +6,9 @@ const raven = require('raven');
 const routes = require('../routes');
 
 
-exports.home = [
-  function (req, res, next) {
-    res.render('home.html');
-  }
-];
+exports.home = function (req, res, next) {
+  res.render('home.html');
+};
 
 
 exports.error_test = function (req, res, next) {

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -4,29 +4,31 @@ const { App, Bucket, User } = require('../models');
 exports.list_buckets = (req, res, next) => {
   Bucket.list()
     .then((buckets) => {
-      res.render('buckets/list.html', {buckets: buckets}); })
+      res.render('buckets/list.html', { buckets });
+    })
     .catch(next);
 };
 
 
 exports.new_bucket = (req, res) => {
-  res.render('buckets/new.html', { prefix: process.env.ENV + '-' });
+  res.render('buckets/new.html', { prefix: `${process.env.ENV}-` });
 };
 
 
-exports.create_bucket = (req, res, next) => {
+exports.create_bucket = (req, res) => {
   new Bucket({
     name: req.body['new-datasource-name'],
-    apps3buckets: []
+    apps3buckets: [],
   })
     .create()
     .then((bucket) => {
-      const { url_for } = require('../routes');
-      res.redirect(url_for('buckets.details', {id: bucket.id})); })
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
+      res.redirect(url_for('buckets.details', { id: bucket.id }));
+    })
     .catch((error) => {
       res.render('buckets/new.html', {
-        bucket: {name: req.body['new-datasource-name']},
-        error: error
+        bucket: { name: req.body['new-datasource-name'] },
+        error,
       });
     });
 };
@@ -36,10 +38,10 @@ exports.bucket_details = (req, res, next) => {
   Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
     .then(([bucket, apps, users]) => {
       res.render('buckets/details.html', {
-        bucket: bucket,
+        bucket,
         apps_options: apps.exclude(bucket.apps),
         users_options: users.exclude(bucket.users),
       });
     })
-    .catch(next)
+    .catch(next);
 };

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -1,9 +1,7 @@
-const { ensureLoggedIn } = require('connect-ensure-login');
 const { App, Bucket, User } = require('../models');
 
 
 exports.list_buckets = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     Bucket.list()
       .then((buckets) => {
@@ -14,7 +12,6 @@ exports.list_buckets = [
 
 
 exports.new_bucket = [
-  ensureLoggedIn('/login'),
   (req, res) => {
     res.render('buckets/new.html', { prefix: process.env.ENV + '-' });
   }
@@ -22,7 +19,6 @@ exports.new_bucket = [
 
 
 exports.create_bucket = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     new Bucket({
       name: req.body['new-datasource-name'],
@@ -43,7 +39,6 @@ exports.create_bucket = [
 
 
 exports.bucket_details = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
       .then(([bucket, apps, users]) => {

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -1,53 +1,45 @@
 const { App, Bucket, User } = require('../models');
 
 
-exports.list_buckets = [
-  (req, res, next) => {
-    Bucket.list()
-      .then((buckets) => {
-        res.render('buckets/list.html', {buckets: buckets}); })
-      .catch(next);
-  }
-];
+exports.list_buckets = (req, res, next) => {
+  Bucket.list()
+    .then((buckets) => {
+      res.render('buckets/list.html', {buckets: buckets}); })
+    .catch(next);
+};
 
 
-exports.new_bucket = [
-  (req, res) => {
-    res.render('buckets/new.html', { prefix: process.env.ENV + '-' });
-  }
-];
+exports.new_bucket = (req, res) => {
+  res.render('buckets/new.html', { prefix: process.env.ENV + '-' });
+};
 
 
-exports.create_bucket = [
-  (req, res, next) => {
-    new Bucket({
-      name: req.body['new-datasource-name'],
-      apps3buckets: []
-    })
-      .create()
-      .then((bucket) => {
-        const { url_for } = require('../routes');
-        res.redirect(url_for('buckets.details', {id: bucket.id})); })
-      .catch((error) => {
-        res.render('buckets/new.html', {
-          bucket: {name: req.body['new-datasource-name']},
-          error: error
-        });
+exports.create_bucket = (req, res, next) => {
+  new Bucket({
+    name: req.body['new-datasource-name'],
+    apps3buckets: []
+  })
+    .create()
+    .then((bucket) => {
+      const { url_for } = require('../routes');
+      res.redirect(url_for('buckets.details', {id: bucket.id})); })
+    .catch((error) => {
+      res.render('buckets/new.html', {
+        bucket: {name: req.body['new-datasource-name']},
+        error: error
       });
-  }
-];
+    });
+};
 
 
-exports.bucket_details = [
-  (req, res, next) => {
-    Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
-      .then(([bucket, apps, users]) => {
-        res.render('buckets/details.html', {
-          bucket: bucket,
-          apps_options: apps.exclude(bucket.apps),
-          users_options: users.exclude(bucket.users),
-        });
-      })
-      .catch(next)
-  },
-];
+exports.bucket_details = (req, res, next) => {
+  Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
+    .then(([bucket, apps, users]) => {
+      res.render('buckets/details.html', {
+        bucket: bucket,
+        apps_options: apps.exclude(bucket.apps),
+        users_options: users.exclude(bucket.users),
+      });
+    })
+    .catch(next)
+};

--- a/app/config.js
+++ b/app/config.js
@@ -32,6 +32,16 @@ config.auth0 = {
   passReqToCallback: true
 };
 
+config.ensure_login = {
+  exclude: [
+    /^\/callback/,
+    /^\/error/,
+    /^\/login/,
+    /^\/logout/,
+    /^\/static/
+  ]
+};
+
 config.express = {
   port: process.env.EXPRESS_PORT || 3000,
   host: process.env.EXPRESS_HOST || '127.0.0.1'
@@ -63,6 +73,7 @@ config.middleware = [
   'authentication',
   'api',
   'template-locals',
+  'ensure-login',
   'routes',
   '404',
   'raven-error-handler',

--- a/app/middleware/ensure-login.js
+++ b/app/middleware/ensure-login.js
@@ -1,0 +1,18 @@
+module.exports = (app, conf, log) => {
+  log.info('adding ensure-login');
+
+  const { ensureLoggedIn } = require('connect-ensure-login');
+  const { exclude } = require('../config').ensure_login;
+  const llog = require('bole')('ensure-login');
+
+  return (req, res, next) => {
+
+    for (let i in exclude) {
+      if (req.url.match(exclude[i])) {
+        return next();
+      }
+    }
+
+    return ensureLoggedIn('/login')(req, res, next);
+  };
+};

--- a/app/users/handlers.js
+++ b/app/users/handlers.js
@@ -4,7 +4,8 @@ const { App, Bucket, User } = require('../models');
 exports.list_users = (req, res, next) => {
   User.list()
     .then((users) => {
-      res.render('users/list.html', {users: users}); })
+      res.render('users/list.html', { users });
+    })
     .catch(next);
 };
 
@@ -15,8 +16,9 @@ exports.user_details = (req, res, next) => {
     .then((user) => {
       res.render('users/details.html', {
         signedInuser: user.auth0_id === req.user.sub,
-        user: user,
-      }); })
+        user,
+      });
+    })
     .catch(next);
 };
 
@@ -25,7 +27,7 @@ exports.user_edit = (req, res, next) => {
   Promise.all([User.get(req.params.id), App.list(), Bucket.list()])
     .then(([user, apps, buckets]) => {
       res.render('users/edit.html', {
-        user: user,
+        user,
         apps_options: apps.exclude(user.apps),
         buckets_options: buckets.exclude(user.buckets),
       });

--- a/app/users/handlers.js
+++ b/app/users/handlers.js
@@ -1,43 +1,34 @@
 const { App, Bucket, User } = require('../models');
 
 
-exports.list_users = [
-  (req, res, next) => {
-    User.list()
-      .then((users) => {
-        res.render('users/list.html', {users: users}); })
-      .catch(next);
-  }
-];
+exports.list_users = (req, res, next) => {
+  User.list()
+    .then((users) => {
+      res.render('users/list.html', {users: users}); })
+    .catch(next);
+};
+
+exports.new_user = (req, res) => { res.render('users/new.html'); };
+
+exports.user_details = (req, res, next) => {
+  User.get(req.params.id)
+    .then((user) => {
+      res.render('users/details.html', {
+        signedInuser: user.auth0_id === req.user.sub,
+        user: user,
+      }); })
+    .catch(next);
+};
 
 
-exports.new_user = [
-  (req, res) => { res.render('users/new.html'); }
-];
-
-exports.user_details = [
-  (req, res, next) => {
-    User.get(req.params.id)
-      .then((user) => {
-        res.render('users/details.html', {
-          signedInuser: user.auth0_id === req.user.sub,
-          user: user,
-        }); })
-      .catch(next);
-  }
-];
-
-
-exports.user_edit = [
-  (req, res, next) => {
-    Promise.all([User.get(req.params.id), App.list(), Bucket.list()])
-      .then(([user, apps, buckets]) => {
-        res.render('users/edit.html', {
-          user: user,
-          apps_options: apps.exclude(user.apps),
-          buckets_options: buckets.exclude(user.buckets),
-        });
-      })
-      .catch(next);
-  },
-];
+exports.user_edit = (req, res, next) => {
+  Promise.all([User.get(req.params.id), App.list(), Bucket.list()])
+    .then(([user, apps, buckets]) => {
+      res.render('users/edit.html', {
+        user: user,
+        apps_options: apps.exclude(user.apps),
+        buckets_options: buckets.exclude(user.buckets),
+      });
+    })
+    .catch(next);
+};

--- a/app/users/handlers.js
+++ b/app/users/handlers.js
@@ -1,9 +1,7 @@
 const { App, Bucket, User } = require('../models');
-const { ensureLoggedIn } = require('connect-ensure-login');
 
 
 exports.list_users = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     User.list()
       .then((users) => {
@@ -14,12 +12,10 @@ exports.list_users = [
 
 
 exports.new_user = [
-  ensureLoggedIn('/login'),
   (req, res) => { res.render('users/new.html'); }
 ];
 
 exports.user_details = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     User.get(req.params.id)
       .then((user) => {
@@ -33,7 +29,6 @@ exports.user_details = [
 
 
 exports.user_edit = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     Promise.all([User.get(req.params.id), App.list(), Bucket.list()])
       .then(([user, apps, buckets]) => {

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -12,8 +12,9 @@ exports.create = (req, res, next) => {
   })
     .create()
     .then(() => {
-      const { url_for } = require('../routes');
-      res.redirect(url_for('buckets.details', { id: bucket_id })); })
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
+      res.redirect(url_for('buckets.details', { id: bucket_id }));
+    })
     .catch(next);
 };
 
@@ -23,7 +24,7 @@ exports.update = (req, res, next) => {
 
   new UserS3Bucket({
     id: users3bucket_id,
-    access_level: access_level,
+    access_level,
   })
     .update()
     .then(() => { res.redirect(redirect_to); })

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -1,9 +1,7 @@
-const { ensureLoggedIn } = require('connect-ensure-login');
 const { UserS3Bucket } = require('../models');
 
 
 exports.create = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     const { user_id, bucket_id } = req.body;
 
@@ -22,7 +20,6 @@ exports.create = [
 ];
 
 exports.update = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     const users3bucket_id = req.params.id;
     const { access_level, redirect_to } = req.body;
@@ -38,7 +35,6 @@ exports.update = [
 ];
 
 exports.delete = [
-  ensureLoggedIn('/login'),
   (req, res, next) => {
     UserS3Bucket.delete(req.params.id)
       .then(() => { res.redirect(req.body.redirect_to); })

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -1,43 +1,37 @@
 const { UserS3Bucket } = require('../models');
 
 
-exports.create = [
-  (req, res, next) => {
-    const { user_id, bucket_id } = req.body;
+exports.create = (req, res, next) => {
+  const { user_id, bucket_id } = req.body;
 
-    new UserS3Bucket({
-      user: user_id,
-      s3bucket: bucket_id,
-      access_level: 'readonly',
-      is_admin: false,
-    })
-      .create()
-      .then(() => {
-        const { url_for } = require('../routes');
-        res.redirect(url_for('buckets.details', { id: bucket_id })); })
-      .catch(next);
-  },
-];
+  new UserS3Bucket({
+    user: user_id,
+    s3bucket: bucket_id,
+    access_level: 'readonly',
+    is_admin: false,
+  })
+    .create()
+    .then(() => {
+      const { url_for } = require('../routes');
+      res.redirect(url_for('buckets.details', { id: bucket_id })); })
+    .catch(next);
+};
 
-exports.update = [
-  (req, res, next) => {
-    const users3bucket_id = req.params.id;
-    const { access_level, redirect_to } = req.body;
+exports.update = (req, res, next) => {
+  const users3bucket_id = req.params.id;
+  const { access_level, redirect_to } = req.body;
 
-    new UserS3Bucket({
-      id: users3bucket_id,
-      access_level: access_level,
-    })
-      .update()
-      .then(() => { res.redirect(redirect_to); })
-      .catch(next);
-  },
-];
+  new UserS3Bucket({
+    id: users3bucket_id,
+    access_level: access_level,
+  })
+    .update()
+    .then(() => { res.redirect(redirect_to); })
+    .catch(next);
+};
 
-exports.delete = [
-  (req, res, next) => {
-    UserS3Bucket.delete(req.params.id)
-      .then(() => { res.redirect(req.body.redirect_to); })
-      .catch(next);
-  },
-];
+exports.delete = (req, res, next) => {
+  UserS3Bucket.delete(req.params.id)
+    .then(() => { res.redirect(req.body.redirect_to); })
+    .catch(next);
+};

--- a/test/test-app-delete.js
+++ b/test/test-app-delete.js
@@ -28,7 +28,7 @@ describe('Delete app', () => {
           },
         };
 
-        handlers.delete[1](req, res, reject);
+        handlers.app_delete(req, res, reject);
       });
 
       return request

--- a/test/test-app-delete.js
+++ b/test/test-app-delete.js
@@ -28,7 +28,7 @@ describe('Delete app', () => {
           },
         };
 
-        handlers.app_delete(req, res, reject);
+        handlers.delete(req, res, reject);
       });
 
       return request

--- a/test/test-app-edit.js
+++ b/test/test-app-edit.js
@@ -33,7 +33,7 @@ describe('Edit app form', () => {
           }
         };
 
-        handlers.app_details(req, res, reject);
+        handlers.details(req, res, reject);
       });
 
       const expected = {

--- a/test/test-app-edit.js
+++ b/test/test-app-edit.js
@@ -33,7 +33,7 @@ describe('Edit app form', () => {
           }
         };
 
-        handlers.details[1](req, res, reject);
+        handlers.app_details(req, res, reject);
       });
 
       const expected = {

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -35,7 +35,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.create[1](req, res, reject);
+        handlers.create(req, res, reject);
       });
 
       return request

--- a/test/test-apps3buckets-delete.js
+++ b/test/test-apps3buckets-delete.js
@@ -28,7 +28,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.delete[1](req, res, reject);
+        handlers.delete(req, res, reject);
       });
 
       return request

--- a/test/test-apps3buckets-update.js
+++ b/test/test-apps3buckets-update.js
@@ -32,7 +32,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.update[1](req, res, reject);
+        handlers.update(req, res, reject);
       });
 
       return request

--- a/test/test-bucket-details.js
+++ b/test/test-bucket-details.js
@@ -35,7 +35,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.bucket_details[1](req, res, reject);
+        handlers.bucket_details(req, res, reject);
       });
 
       const expected = {

--- a/test/test-buckets-views.js
+++ b/test/test-buckets-views.js
@@ -39,7 +39,7 @@ describe('buckets view', () => {
         req.body = bucket_data;
         res.redirect = resolve;
         res.render = unexpected;
-        handlers.create_bucket[1](req, res, reject);
+        handlers.create_bucket(req, res, reject);
       });
 
       return request

--- a/test/test-user-edit.js
+++ b/test/test-user-edit.js
@@ -28,7 +28,7 @@ describe('Edit user form', () => {
           },
         };
 
-        handlers.user_edit[1](req, res, reject);
+        handlers.user_edit(req, res, reject);
       });
 
       const expected = {

--- a/test/test-users3buckets-create.js
+++ b/test/test-users3buckets-create.js
@@ -35,7 +35,7 @@ describe('Edit bucket form', () => {
           }
         };
 
-        handlers.create[1](req, res, reject);
+        handlers.create(req, res, reject);
       });
 
       return request

--- a/test/test-users3buckets-delete.js
+++ b/test/test-users3buckets-delete.js
@@ -26,7 +26,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.delete[1](req, res, reject);
+        handlers.delete(req, res, reject);
       });
 
       return request

--- a/test/test-users3buckets-update.js
+++ b/test/test-users3buckets-update.js
@@ -30,7 +30,7 @@ describe('Edit bucket form', () => {
           },
         };
 
-        handlers.update[1](req, res, reject);
+        handlers.update(req, res, reject);
       });
 
       return request


### PR DESCRIPTION
## What

* Add `ensure-login` middleware as listing paths that do not require login is simpler than decorating every route that does require it.
* Added excluded paths to config
* Tidied up handlers which no longer need to be arrays, and fixed corresponding tests

## How to review

1. Nothing should be visibly different, except the code, and a new log message on startup: `info middleware: adding ensure-login`