### PR TITLE
Disable animations on login widget

### DIFF
--- a/app/assets/sass/local/login.scss
+++ b/app/assets/sass/local/login.scss
@@ -1,3 +1,10 @@
+#a0-lock * {
+  -webkit-animation: none !important;
+  animation: none !important;
+  -webkit-transition: none !important;
+  transition: none !important;
+}
+
 .login-container {
   padding-top: 4em;
 


### PR DESCRIPTION
## What

The CSS animations on the lock widget are unnecessary and annoying, plus disabling them also disables the Gravatar and forces the crown logo.

## How to review

1. Describe the steps required to test the changes
2. ???
3. Profit!

Provide [http://example.com](links) to relevant tickets, articles or other
resources.

Note the Trello Github integration links tickets to PRs/branches/commits (in
both directions).
