### PR TITLE
Connect existing data source to new app at creation

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -20,9 +20,16 @@ exports.create = (req, res, next) => {
     repo_url: req.body.repo_url,
     userapps: [],
   });
+  let new_app;
 
   app.create()
-    .then((new_app) => {
+    .then((created_app) => {
+      if(req.body['new-app-datasource'] === 'select') {
+        created_app.grant_bucket_access(req.body['select-existing-datasource'], 'readonly');
+      }
+      new_app = created_app;
+    })
+    .then(() => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
       res.redirect(url_for('apps.details', { id: new_app.id }));
     })


### PR DESCRIPTION
## What

Allow user to connect an existing data source to a new app as they create it rather than having to "do this later".

TODO: filter the list of existing data sources to only ones the user is allowed to see.

## How to review

1. log in
2. have at least one data source (bucket) in your db
3. click "Create new app"
4. fill in app name and repo url
5. select "Connect an existing app data source"
6. select a bucket from dropdown and submit form
7. use the time you just saved by not having to do this separately to save the world
