### PR TITLE
Build Docker image faster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+static

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ MAINTAINER Andy Driver <andy.driver@digital.justice.gov.uk>
 
 WORKDIR /home/cpanel
 
+ADD package.json package.json
+RUN npm install
+
 ADD app app/
 ADD bin bin/
-ADD package.json package.json
-
-RUN npm install
-ADD node_modules node_modules/
 
 RUN npm run-script collect-static
-ADD static static/
 
 ENV EXPRESS_HOST "0.0.0.0"
 ENV NODE_RESTART "0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /home/cpanel
 ADD package.json package.json
 RUN npm install
 
-ADD app app/
 ADD bin bin/
+ADD app app/
 
 RUN npm run-script collect-static
 


### PR DESCRIPTION
- Don't include generated things into docker context (`node_modules` and
  `static` are generated inside the container, no reason to pass them in)
- Moved addition of `/app` and `/bin` AFTER `npm_install`, this is slow
  and only needs to be run again if `packages.json` changes, not if any of
  the application's files change.

### See
- https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#use-a-dockerignore-file
- article with a similar example of a Dockerfile for a node app https://ngeor.wordpress.com/2017/11/15/cd-with-helm-part-1-dockerize-it/
