### PR TITLE
Kubernetes API client and models

### DIFF
--- a/app/api-client.js
+++ b/app/api-client.js
@@ -24,6 +24,8 @@ class JWTAuth {
   }
 }
 
+exports.JWTAuth = JWTAuth;
+
 
 class APIClient {
   constructor(conf) {
@@ -31,7 +33,7 @@ class APIClient {
     this.auth = null;
   }
 
-  request(endpoint, method = 'GET', body = null) {
+  request(endpoint, { method='GET', body=null, params={} } = {}) {
     const headers = {};
 
     if (this.auth) {
@@ -44,11 +46,12 @@ class APIClient {
         uri: this.endpoint_url(endpoint),
         headers,
         body,
+        qs: params,
         json: true,
       };
+      log.debug(`${method} ${options.uri}`);
       return request(options)
         .then((result) => {
-          log.debug(`${method} ${options.uri}`);
           // console.dir(result);
           return result;
         });
@@ -57,24 +60,24 @@ class APIClient {
     }
   }
 
-  get(endpoint) {
-    return this.request(endpoint);
+  get(endpoint, params = {}) {
+    return this.request(endpoint, { params });
   }
 
   post(endpoint, body = '') {
-    return this.request(endpoint, 'POST', body);
+    return this.request(endpoint, { method: 'POST', body });
   }
 
-  delete(endpoint) {
-    return this.request(endpoint, 'DELETE');
+  delete(endpoint, params = {}) {
+    return this.request(endpoint, { method: 'DELETE', params });
   }
 
   patch(endpoint, body = '') {
-    return this.request(endpoint, 'PATCH', body);
+    return this.request(endpoint, { method: 'PATCH', body});
   }
 
   put(endpoint, body = '') {
-    return this.request(endpoint, 'PUT', body);
+    return this.request(endpoint, { method: 'PUT', body});
   }
 
   endpoint_url(endpoint) {
@@ -91,6 +94,7 @@ class APIClient {
   }
 }
 
+exports.APIClient = APIClient;
 
 const api = new APIClient(config.api);
 api.auth = new JWTAuth();

--- a/app/k8s-api-client.js
+++ b/app/k8s-api-client.js
@@ -1,0 +1,27 @@
+const config = require('./config');
+const { APIClient, JWTAuth } = require('./api-client');
+const url = require('url');
+
+
+class KubernetesAPIClient extends APIClient {
+  endpoint_url(endpoint, namespace = 'default') {
+    if (!endpoint) {
+      throw new Error('Missing endpoint');
+    }
+
+    const api = {
+      'deployments': 'apis/apps/v1beta2',
+      'pods': 'api/v1',
+    }[endpoint];
+
+    return url.resolve(this.base_url, `k8s/${api}/namespaces/${namespace}/${endpoint}`);
+  }
+}
+
+
+exports.KubernetesAPIClient = KubernetesAPIClient;
+
+const api = new KubernetesAPIClient(config.api);
+api.auth = new JWTAuth();
+
+exports.api = api;

--- a/app/k8s-api-client.js
+++ b/app/k8s-api-client.js
@@ -4,9 +4,18 @@ const url = require('url');
 
 
 class KubernetesAPIClient extends APIClient {
-  endpoint_url(endpoint, namespace = 'default') {
+  endpoint_url(endpoint, namespace = undefined) {
     if (!endpoint) {
       throw new Error('Missing endpoint');
+    }
+
+    let ns = namespace;
+    if (!namespace) {
+      ns = this.namespace;
+
+      if (!ns) {
+        ns = 'default';
+      }
     }
 
     const api = {
@@ -14,7 +23,7 @@ class KubernetesAPIClient extends APIClient {
       'pods': 'api/v1',
     }[endpoint];
 
-    return url.resolve(this.base_url, `k8s/${api}/namespaces/${namespace}/${endpoint}`);
+    return url.resolve(this.base_url, `k8s/${api}/namespaces/${ns}/${endpoint}`);
   }
 }
 

--- a/app/k8s-api-client.js
+++ b/app/k8s-api-client.js
@@ -26,14 +26,7 @@ class KubernetesAPIClient extends APIClient {
       throw new Error('Missing endpoint');
     }
 
-    let ns = namespace;
-    if (!namespace) {
-      ns = this.namespace;
-
-      if (!ns) {
-        ns = 'default';
-      }
-    }
+    let ns = namespace || this.namespace || 'default';
 
     const api = {
       'deployments': 'apis/apps/v1beta2',

--- a/app/k8s-api-client.js
+++ b/app/k8s-api-client.js
@@ -3,6 +3,23 @@ const { APIClient, JWTAuth } = require('./api-client');
 const url = require('url');
 
 
+function get_namespace(username) {
+  // kubernetes namespaces must be valid DNS names
+  let s = `user-${username.toLowerCase()}`;
+  // may contain only alphanumeric characters and hyphens
+  s = s.replace(/[^a-z0-9]+/, '-');
+  // must start with an alphanumeric character
+  s = s.replace(/^[^a-z0-9]*/, '');
+  // must be at most 63 characters
+  s = s.slice(0, 63);
+  // must end with an alphanumeric character
+  s = s.replace(/[^a-z0-9]*$/, '');
+  return s;
+}
+
+exports.get_namespace = get_namespace;
+
+
 class KubernetesAPIClient extends APIClient {
   endpoint_url(endpoint, namespace = undefined) {
     if (!endpoint) {

--- a/app/k8s-model.js
+++ b/app/k8s-model.js
@@ -1,0 +1,22 @@
+const { Model, ModelSet } = require('./base-model');
+const { api } = require('./k8s-api-client');
+
+
+class K8sModel extends Model {
+  static list(params = {}) {
+    return api.get(this.endpoint, params)
+      .then(result => new ModelSet(this.prototype.constructor, result.items));
+  }
+
+  static get(name) {
+    return api.get(`${this.endpoint}/${name}`)
+      .then(data => new this.prototype.constructor(data));
+  }
+
+  static delete_all(params = {}) {
+    return api.delete(this.endpoint, params);
+  }
+}
+
+
+exports.K8sModel = K8sModel;

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -1,9 +1,21 @@
+function sanitize_username(username) {
+  let s = username.toLowerCase();
+  s = s.replace(/[^a-z0-9]+/, '-');
+  s = s.replace(/^[^a-z0-9]*/, '');
+  s = s.slice(0, 63);
+  s = s.replace(/[^a-z0-9]*$/, '');
+  return s;
+}
+
+
 module.exports = (app, conf, log) => {
   log.info('adding api');
   return (req, res, next) => {
     if (req.user && req.user.id_token) {
       const { api } = require('../api-client');
+      const k8s_api = require('../k8s-api-client').api;
       api.auth.set_token(req.user.id_token);
+      k8s_api.namespace = `user-${sanitize_username(req.user.username)}`;
     }
     next();
   };

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -1,21 +1,11 @@
-function sanitize_username(username) {
-  let s = username.toLowerCase();
-  s = s.replace(/[^a-z0-9]+/, '-');
-  s = s.replace(/^[^a-z0-9]*/, '');
-  s = s.slice(0, 63);
-  s = s.replace(/[^a-z0-9]*$/, '');
-  return s;
-}
-
-
 module.exports = (app, conf, log) => {
   log.info('adding api');
   return (req, res, next) => {
     if (req.user && req.user.id_token) {
       const { api } = require('../api-client');
-      const k8s_api = require('../k8s-api-client').api;
+      const k8s = require('../k8s-api-client');
       api.auth.set_token(req.user.id_token);
-      k8s_api.namespace = `user-${sanitize_username(req.user.username)}`;
+      k8s.api.namespace = k8s.get_namespace(req.user.username);
     }
     next();
   };

--- a/app/models.js
+++ b/app/models.js
@@ -1,4 +1,5 @@
 const { Model, ModelSet } = require('./base-model');
+const { K8sModel } = require('./k8s-model');
 
 
 class App extends Model {
@@ -133,3 +134,29 @@ class UserApp extends Model {
 }
 
 exports.UserApp = UserApp;
+
+
+class Deployment extends K8sModel {
+  static get endpoint() {
+    return 'deployments';
+  }
+
+  get_pods() {
+    return Pod.list({ labelSelector: `app=${this.data.metadata.labels.app}` });
+  }
+
+  restart() {
+    return Pod.delete_all({ labelSelector: `app=${this.data.metadata.labels.app}` });
+  }
+}
+
+exports.Deployment = Deployment;
+
+
+class Pod extends K8sModel {
+  static get endpoint() {
+    return 'pods';
+  }
+}
+
+exports.Pod = Pod;

--- a/test/fixtures/deployment-pods.js
+++ b/test/fixtures/deployment-pods.js
@@ -1,0 +1,333 @@
+module.exports = {
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "annotations": {
+                    "iam.amazonaws.com/role": "alpha_user_andyhd",
+                    "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"user-andyhd\",\"name\":\"andyhd-rstudio-rstudio-4159917267\",\"uid\":\"d081709c-b589-11e7-a28d-06efce866f16\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"45480082\"}}\n"
+                },
+                "creationTimestamp": "2017-12-02T17:41:40Z",
+                "generateName": "andyhd-rstudio-rstudio-4159917267-",
+                "labels": {
+                    "app": "rstudio",
+                    "pod-template-hash": "4159917267"
+                },
+                "name": "andyhd-rstudio-rstudio-4159917267-vlb52",
+                "namespace": "user-andyhd",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "extensions/v1beta1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "andyhd-rstudio-rstudio-4159917267",
+                        "uid": "d081709c-b589-11e7-a28d-06efce866f16"
+                    }
+                ],
+                "resourceVersion": "45724902",
+                "selfLink": "/api/v1/namespaces/user-andyhd/pods/andyhd-rstudio-rstudio-4159917267-vlb52",
+                "uid": "0e0bb930-d788-11e7-8b5e-0203ba1d24e6"
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "env": [
+                            {
+                                "name": "USER",
+                                "value": "andyhd"
+                            },
+                            {
+                                "name": "AUTH0_CLIENT_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "client_secret",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "AUTH0_CLIENT_ID",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "client_id",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "AUTH0_DOMAIN",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "domain",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "AUTH0_CALLBACK_URL",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "callback_url",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "COOKIE_SECRET",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "cookie_secret",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SECURE_COOKIE_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "secure_cookie_key",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "PROXY_TARGET_HOST",
+                                "value": "localhost"
+                            },
+                            {
+                                "name": "PROXY_TARGET_PORT",
+                                "value": "8787"
+                            },
+                            {
+                                "name": "EXPRESS_HOST",
+                                "value": "0.0.0.0"
+                            },
+                            {
+                                "name": "EXPRESS_PORT",
+                                "value": "3000"
+                            }
+                        ],
+                        "image": "quay.io/mojanalytics/rstudio-auth-proxy:v1.2.0",
+                        "imagePullPolicy": "Always",
+                        "name": "rstudio-auth-proxy",
+                        "ports": [
+                            {
+                                "containerPort": 3000,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/login?healthz",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "25m",
+                                "memory": "64Mi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "default-token-vjhqm",
+                                "readOnly": true
+                            }
+                        ]
+                    },
+                    {
+                        "env": [
+                            {
+                                "name": "USER",
+                                "value": "andyhd"
+                            },
+                            {
+                                "name": "AWS_DEFAULT_REGION",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "aws_default_region",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "SECURE_COOKIE_KEY",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "key": "secure_cookie_key",
+                                        "name": "andyhd-rstudio-rstudio"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "TOOLS_DOMAIN",
+                                "value": "tools.alpha.mojanalytics.xyz"
+                            }
+                        ],
+                        "image": "quay.io/mojanalytics/rstudio:v1.3.1",
+                        "imagePullPolicy": "Always",
+                        "name": "r-studio-server",
+                        "ports": [
+                            {
+                                "containerPort": 8787,
+                                "name": "http",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/",
+                                "port": "http",
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 5,
+                            "periodSeconds": 5,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "cpu": "1500m",
+                                "memory": "12Gi"
+                            },
+                            "requests": {
+                                "cpu": "200m",
+                                "memory": "1Gi"
+                            }
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/home/andyhd",
+                                "name": "home"
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "default-token-vjhqm",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "nodeName": "ip-192-168-14-177.eu-west-1.compute.internal",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "default",
+                "serviceAccountName": "default",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.alpha.kubernetes.io/notReady",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.alpha.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "home",
+                        "persistentVolumeClaim": {
+                            "claimName": "nfs-home"
+                        }
+                    },
+                    {
+                        "name": "default-token-vjhqm",
+                        "secret": {
+                            "defaultMode": 420,
+                            "secretName": "default-token-vjhqm"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2017-12-02T17:41:41Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2017-12-02T17:45:42Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2017-12-02T17:41:40Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "docker://e36217b50b92407e23117964ae1f6106ff15c11262d8a63fe0201e14f9534836",
+                        "image": "quay.io/mojanalytics/rstudio:v1.3.1",
+                        "imageID": "docker-pullable://quay.io/mojanalytics/rstudio@sha256:3758eb7dd69e83cbe75ee5538fc57665f2d67fca060da0af0aeac934642172d6",
+                        "lastState": {},
+                        "name": "r-studio-server",
+                        "ready": true,
+                        "restartCount": 0,
+                        "state": {
+                            "running": {
+                                "startedAt": "2017-12-02T17:45:35Z"
+                            }
+                        }
+                    },
+                    {
+                        "containerID": "docker://541a995a907bd07f8bbe9a30d2ff1a104086405470402e5d48c7fe61a8d5740c",
+                        "image": "quay.io/mojanalytics/rstudio-auth-proxy:v1.2.0",
+                        "imageID": "docker-pullable://quay.io/mojanalytics/rstudio-auth-proxy@sha256:201ae293c91df0cb1b47e3af7e20841f1b7912be9d02e7daffd70aa4bc6022b9",
+                        "lastState": {},
+                        "name": "rstudio-auth-proxy",
+                        "ready": true,
+                        "restartCount": 0,
+                        "state": {
+                            "running": {
+                                "startedAt": "2017-12-02T17:43:17Z"
+                            }
+                        }
+                    }
+                ],
+                "hostIP": "192.168.14.177",
+                "phase": "Running",
+                "podIP": "100.79.122.143",
+                "qosClass": "Burstable",
+                "startTime": "2017-12-02T17:41:41Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+};

--- a/test/fixtures/deployments.js
+++ b/test/fixtures/deployments.js
@@ -1,0 +1,272 @@
+module.exports = {
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "2"
+                },
+                "creationTimestamp": "2017-10-17T12:39:44Z",
+                "generation": 2,
+                "labels": {
+                    "app": "rstudio",
+                    "chart": "rstudio-1.2.5"
+                },
+                "name": "andyhd-rstudio-rstudio",
+                "namespace": "user-andyhd",
+                "resourceVersion": "45724905",
+                "selfLink": "/apis/extensions/v1beta1/namespaces/user-andyhd/deployments/andyhd-rstudio-rstudio",
+                "uid": "40de5854-b338-11e7-bc33-022284ce4e76"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "matchLabels": {
+                        "app": "rstudio"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 1,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "annotations": {
+                            "iam.amazonaws.com/role": "alpha_user_andyhd"
+                        },
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "rstudio"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "env": [
+                                    {
+                                        "name": "USER",
+                                        "value": "andyhd"
+                                    },
+                                    {
+                                        "name": "AUTH0_CLIENT_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "client_secret",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AUTH0_CLIENT_ID",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "client_id",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AUTH0_DOMAIN",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "domain",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AUTH0_CALLBACK_URL",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "callback_url",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "COOKIE_SECRET",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "cookie_secret",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "SECURE_COOKIE_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "secure_cookie_key",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "PROXY_TARGET_HOST",
+                                        "value": "localhost"
+                                    },
+                                    {
+                                        "name": "PROXY_TARGET_PORT",
+                                        "value": "8787"
+                                    },
+                                    {
+                                        "name": "EXPRESS_HOST",
+                                        "value": "0.0.0.0"
+                                    },
+                                    {
+                                        "name": "EXPRESS_PORT",
+                                        "value": "3000"
+                                    }
+                                ],
+                                "image": "quay.io/mojanalytics/rstudio-auth-proxy:v1.2.0",
+                                "imagePullPolicy": "Always",
+                                "name": "rstudio-auth-proxy",
+                                "ports": [
+                                    {
+                                        "containerPort": 3000,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/login?healthz",
+                                        "port": "http",
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "periodSeconds": 5,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "25m",
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            },
+                            {
+                                "env": [
+                                    {
+                                        "name": "USER",
+                                        "value": "andyhd"
+                                    },
+                                    {
+                                        "name": "AWS_DEFAULT_REGION",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "aws_default_region",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "SECURE_COOKIE_KEY",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "secure_cookie_key",
+                                                "name": "andyhd-rstudio-rstudio"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "TOOLS_DOMAIN",
+                                        "value": "tools.alpha.mojanalytics.xyz"
+                                    }
+                                ],
+                                "image": "quay.io/mojanalytics/rstudio:v1.3.1",
+                                "imagePullPolicy": "Always",
+                                "name": "r-studio-server",
+                                "ports": [
+                                    {
+                                        "containerPort": 8787,
+                                        "name": "http",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "failureThreshold": 3,
+                                    "httpGet": {
+                                        "path": "/",
+                                        "port": "http",
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "periodSeconds": 5,
+                                    "successThreshold": 1,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "1500m",
+                                        "memory": "12Gi"
+                                    },
+                                    "requests": {
+                                        "cpu": "200m",
+                                        "memory": "1Gi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/home/andyhd",
+                                        "name": "home"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "volumes": [
+                            {
+                                "name": "home",
+                                "persistentVolumeClaim": {
+                                    "claimName": "nfs-home"
+                                }
+                            }
+                        ]
+                    }
+                }
+            },
+            "status": {
+                "availableReplicas": 1,
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2017-10-17T12:39:44Z",
+                        "lastUpdateTime": "2017-10-17T12:39:44Z",
+                        "message": "Deployment has minimum availability.",
+                        "reason": "MinimumReplicasAvailable",
+                        "status": "True",
+                        "type": "Available"
+                    }
+                ],
+                "observedGeneration": 2,
+                "readyReplicas": 1,
+                "replicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+};

--- a/test/test-k8s-api-client.js
+++ b/test/test-k8s-api-client.js
@@ -1,0 +1,25 @@
+const { assert } = require('chai');
+const { config, mock_api } = require('./conftest');
+const { ModelSet } = require('../app/base-model');
+const { Deployment } = require('../app/models');
+
+
+describe('KubernetesAPIClient', () => {
+
+  it('builds a URL based on endpoint name', () => {
+    const deployments_response = require('./fixtures/deployments');
+    const url = `/k8s/apis/apps/v1beta2/namespaces/default/deployments`;
+    const expected = new ModelSet(Deployment, deployments_response.items);
+
+    const request = mock_api()
+      .get(url)
+      .reply(200, deployments_response);
+
+    return Deployment.list()
+      .then((tools) => {
+        assert(request.isDone(), 'deployments API not called');
+        assert.deepEqual(tools, expected);
+      });
+  });
+});
+

--- a/test/test-k8s-api-client.js
+++ b/test/test-k8s-api-client.js
@@ -1,5 +1,6 @@
 const { assert } = require('chai');
 const { config, mock_api } = require('./conftest');
+const { api } = require('../app/k8s-api-client');
 const { ModelSet } = require('../app/base-model');
 const { Deployment } = require('../app/models');
 
@@ -7,13 +8,16 @@ const { Deployment } = require('../app/models');
 describe('KubernetesAPIClient', () => {
 
   it('builds a URL based on endpoint name', () => {
+    const namespace = 'user-andyhd';
     const deployments_response = require('./fixtures/deployments');
-    const url = `/k8s/apis/apps/v1beta2/namespaces/default/deployments`;
+    const url = `/k8s/apis/apps/v1beta2/namespaces/${namespace}/deployments`;
     const expected = new ModelSet(Deployment, deployments_response.items);
 
     const request = mock_api()
       .get(url)
       .reply(200, deployments_response);
+
+    api.namespace = namespace;
 
     return Deployment.list()
       .then((tools) => {

--- a/test/test-k8s-models.js
+++ b/test/test-k8s-models.js
@@ -3,21 +3,20 @@ const { mock_api } = require('./conftest');
 const { api } = require('../app/k8s-api-client');
 const { ModelSet } = require('../app/base-model');
 const { Pod, Deployment } = require('../app/models');
+const deployments = require('./fixtures/deployments').items;
+const pods_response = require('./fixtures/deployment-pods');
 
 
 describe('K8sModel', () => {
   describe('Deployment', () => {
     it('has a number of pods', () => {
       const ns = 'user-test';
-      const deployments_response = require('./fixtures/apps');
-      const pods_response = require('./fixtures/deployment-pods');
       const expected = new ModelSet(Pod, pods_response.items);
+      const rstudio = new Deployment(deployments[0]);
 
       const pods_request = mock_api()
         .get(`/k8s/api/v1/namespaces/${ns}/pods?labelSelector=app%3Drstudio`)
         .reply(200, pods_response);
-
-      const rstudio = new Deployment(require('./fixtures/deployments').items[0]);
 
       api.namespace = ns;
 
@@ -30,7 +29,8 @@ describe('K8sModel', () => {
 
     it('restarts by deleting all pods', () => {
       const ns = 'user-test';
-      const rstudio = new Deployment(require('./fixtures/deployments').items[0]);
+      const rstudio = new Deployment(deployments[0]);
+
       const delete_pods = mock_api()
         .delete(`/k8s/api/v1/namespaces/${ns}/pods?labelSelector=app%3Drstudio`)
         .reply(200, {

--- a/test/test-k8s-models.js
+++ b/test/test-k8s-models.js
@@ -1,0 +1,43 @@
+const { assert } = require('chai');
+const { mock_api } = require('./conftest');
+const { ModelSet } = require('../app/base-model');
+const { Pod, Deployment } = require('../app/models');
+
+
+describe('K8sModel', () => {
+  describe('Deployment', () => {
+    it('has a number of pods', () => {
+      const deployments_response = require('./fixtures/apps');
+      const pods_response = require('./fixtures/deployment-pods');
+      const expected = new ModelSet(Pod, pods_response.items);
+
+      const pods_request = mock_api()
+        .get('/k8s/api/v1/namespaces/default/pods?labelSelector=app%3Drstudio')
+        .reply(200, pods_response);
+
+      const rstudio = new Deployment(require('./fixtures/deployments').items[0]);
+
+      rstudio.get_pods()
+        .then((pods) => {
+          assert(pods_request.isDone());
+          assert.deepEqual(pods, expected);
+        });
+    });
+
+    it('restarts by deleting all pods', () => {
+      const rstudio = new Deployment(require('./fixtures/deployments').items[0]);
+      const delete_pods = mock_api()
+        .delete('/k8s/api/v1/namespaces/default/pods?labelSelector=app%3Drstudio')
+        .reply(200, {
+          'apiVersion': 'v1',
+          'kind': 'Status',
+          'status': 'Success'
+        });
+
+      rstudio.restart()
+        .then(() => {
+          assert(delete_pods.isDone());
+        });
+    });
+  });
+});


### PR DESCRIPTION
## What

* Add Kubernetes API client to abstract making requests to the correct endpoints
* Add `Deployment` and `Pod` models to make dealing with Kubernetes API similar to existing API
* Set the namespace for Kubernetes API calls using the logged in user's username
* Allows listing deployments (tools), eg:
  ```javascript
  Deployment.list()
    .then((tools) => {
      tools.forEach((tool) => {
        console.log(tool.metadata.labels.app); // rstudio
      });
    });
  ```
* Allows restarting RStudio, eg:
  ```javascript
  Deployment.get('andyhd-rstudio-rstudio') // Deployment().metadata.name
    .then((rstudio) => {
      return rstudio.restart();
    });
  ```

See [Trello #516](https://trello.com/c/EYuj7Gfs) and [Trello #510](https://trello.com/c/wympY8SG)