### PR TITLE
Make API error messages friendlier

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -18,8 +18,10 @@ exports.home = (req, res, next) => {
 
 
 exports.error_test = (req, res, next) => {
-  User.get('non-existent')
-    .then((user) => { res.send(user.id); })
+  if (req.query.forbidden) {
+    api.auth.set_token('invalid token');
+  }
+  return User.get('non-existent')
     .catch(next);
 };
 

--- a/app/templates/errors/internal-error.html
+++ b/app/templates/errors/internal-error.html
@@ -1,4 +1,8 @@
-<h1>Internal Error</h1>
+{% extends "layouts/one-column.html" %}
+
+{% set page_title = 'Internal Error' %}
+
+{% block main_column %}
 
 <p class="error">{{ error.message }}</p>
 
@@ -7,18 +11,23 @@
 {{ error.stack | safe }}
 </pre>
 
-<pre>
-session:
-{{ req.session | default({}) | dump(2) | safe }}
-</pre>
+<details class="debug">
+  <summary>Debug</summary>
 
-<pre>
-current_user:
-{{ current_user | dump(2) | safe }}
-</pre>
+  <div class="panel">
+    <h2 class="heading-medium">Session</h2>
+    <pre>{{ req.session | default({}) | dump(2) | safe }}</pre>
+  </div>
 
-<pre>
-env:
-{{ env | dump(2) | safe }}
-</pre>
-{% endif %}
+  <div class="panel">
+    <h2 class="heading-medium">Logged-in user</h2>
+    <pre>{{ current_user | dump(2) | safe }}</pre>
+  </div>
+
+  <div class="panel">
+    <h2 class="heading-medium">Environment</h2>
+    <pre>{{ env | dump(2) | safe }}</pre>
+  </div
+</details>
+  {% endif %}
+{% endblock %}

--- a/test/test-api-client.js
+++ b/test/test-api-client.js
@@ -14,6 +14,7 @@ describe('API Client', () => {
     it('rejects an invalid auth token', () => {
       const reason = {
         'detail': 'Authentication credentials were not provided.'};
+      const expected = 'GET /apps/ was not permitted: Authentication credentials were not provided.';
 
       mock_api()
         .get('/apps/')
@@ -22,7 +23,7 @@ describe('API Client', () => {
 
       return App.list()
         .then((apps) => { throw new Error('expected failure'); })
-        .catch((err) => { assert.deepEqual(err.error, reason); });
+        .catch((err) => { assert.equal(err.message, expected); });
     });
 
     it('accepts a valid auth token', () => {


### PR DESCRIPTION
## What

* Added some specific API error classes to differentiate errors reported to Sentry and add useful information to error message
* Make error template extend GOV.UK template for nicer error pages
* Add URL params to `/error` handler to test different classes of error

## How to review

1. Browse to http://localhost:3000/error
2. See a nicely styled error message with an informative error message
3. Browse to http://localhost:3000/error?forbidden=1
4. See a different class of error