### PR TITLE
Add list and restart tools views

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -1,4 +1,5 @@
 const { api } = require('../api-client');
+const k8s = require('../k8s-api-client');
 const { User } = require('../models');
 const config = require('../config');
 const passport = require('passport');
@@ -30,6 +31,7 @@ exports.auth_callback = [
     raven.setContext({user: req.user});
 
     api.auth.set_token(req.user.id_token);
+    k8s.api.auth.set_token(req.user.id_token);
 
     User.get(req.user.auth0_id)
       .then((user) => {

--- a/app/config.js
+++ b/app/config.js
@@ -21,6 +21,7 @@ config.apps = [
   'users',
   'buckets',
   'apps3buckets',
+  'tools',
   'users3buckets',
   'userapps',
 ];

--- a/app/k8s-api-client.js
+++ b/app/k8s-api-client.js
@@ -22,16 +22,16 @@ exports.get_namespace = get_namespace;
 
 class KubernetesAPIClient extends APIClient {
   endpoint_url(endpoint, namespace = undefined) {
+    let ns = namespace || this.namespace || 'default';
+
     if (!endpoint) {
       throw new Error('Missing endpoint');
     }
 
-    let ns = namespace || this.namespace || 'default';
-
     const api = {
       'deployments': 'apis/apps/v1beta2',
       'pods': 'api/v1',
-    }[endpoint];
+    }[endpoint.split('/')[0]];
 
     return url.resolve(this.base_url, `k8s/${api}/namespaces/${ns}/${endpoint}`);
   }

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -6,6 +6,7 @@ module.exports = (app, conf, log) => {
       const k8s = require('../k8s-api-client');
       api.auth.set_token(req.user.id_token);
       k8s.api.namespace = k8s.get_namespace(req.user.username);
+      k8s.api.auth.set_token(req.user.id_token);
     }
     next();
   };

--- a/app/models.js
+++ b/app/models.js
@@ -154,8 +154,7 @@ class Deployment extends K8sModel {
   }
 
   get_status() {
-    for (let i in this.status.conditions) {
-      let condition = this.status.conditions[i];
+    for (let condition of this.status.conditions) {
       if (condition.type === 'Available') {
         if (condition.status === 'True') {
           return 'Available';

--- a/app/models.js
+++ b/app/models.js
@@ -141,12 +141,30 @@ class Deployment extends K8sModel {
     return 'deployments';
   }
 
+  static restart(label) {
+    return Pod.delete_all({ labelSelector: `app=${label}` });
+  }
+
   get_pods() {
     return Pod.list({ labelSelector: `app=${this.data.metadata.labels.app}` });
   }
 
   restart() {
     return Pod.delete_all({ labelSelector: `app=${this.data.metadata.labels.app}` });
+  }
+
+  get_status() {
+    for (let i in this.status.conditions) {
+      let condition = this.status.conditions[i];
+      if (condition.type === 'Available') {
+        if (condition.status === 'True') {
+          return 'Available';
+        } else {
+          return 'Unavailable';
+        }
+      }
+    }
+    return 'Unknown';
   }
 }
 

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -1,0 +1,38 @@
+{% extends "layouts/one-column.html" %}
+
+{% set page_title = "Tools" %}
+
+{% block main_column %}
+
+<p>{{ tools.length }} tool{%- if tools.length != 1 -%}s{%- endif -%}</p>
+
+{% if tools.length %}
+  <table class="form-group list">
+    <thead>
+      <tr>
+        {% if current_user.is_superuser %}
+        <th>Namespace</th>
+        {% endif %}
+        <th>Name</th>
+        <th>Status</th>
+        <th><span class="visuallyhidden">Actions</span></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for tool in tools %}
+      <tr>
+        {% if current_user.is_superuser %}
+        <td>{{ tool.metadata.namespace }}</td>
+        {% endif %}
+        <td>{{ tool.metadata.labels.app }}</td>
+        <td>{{ tool.get_status() }}</td>
+        <td class="align-right no-wrap">
+          <a class="button button-secondary" href="{{ url_for('tools.restart', {id: tool.metadata.name}) }}">Restart</a>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% endif %}
+
+{% endblock %}

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -11,7 +11,7 @@ exports.list = (req, res, next) => {
 
 
 exports.restart = (req, res, next) => {
-  Deployment.get(req.params.id)
+  Deployment.get(req.params.name)
     .then((tool) => {
       req.session.flash_messages.push(`Restarting ${tool.metadata.name}`);
       return tool.restart();

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,0 +1,24 @@
+const { Deployment, User } = require('../models');
+
+
+exports.list = (req, res, next) => {
+  Deployment.list()
+    .then((tools) => {
+      res.render('tools/list.html', { tools });
+    })
+    .catch(next);
+};
+
+
+exports.restart = (req, res, next) => {
+  Deployment.get(req.params.id)
+    .then((tool) => {
+      req.session.flash_messages.push(`Restarting ${tool.metadata.name}`);
+      return tool.restart();
+    })
+    .then(() => {
+      const { url_for } = require('../routes'); // eslint-disable-line global-require
+      res.redirect(url_for('tools.list'));
+    })
+    .catch(next);
+};

--- a/app/tools/routes.js
+++ b/app/tools/routes.js
@@ -1,0 +1,7 @@
+const handlers = require('./handlers');
+
+
+module.exports = [
+  { name: 'list', pattern: '/tools', handler: handlers.list },
+  { name: 'restart', pattern: '/tools/:id/restart', handler: handlers.restart },
+];

--- a/app/tools/routes.js
+++ b/app/tools/routes.js
@@ -3,5 +3,5 @@ const handlers = require('./handlers');
 
 module.exports = [
   { name: 'list', pattern: '/tools', handler: handlers.list },
-  { name: 'restart', pattern: '/tools/:id/restart', handler: handlers.restart },
+  { name: 'restart', pattern: '/tools/:name/restart', handler: handlers.restart },
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,9 @@ services:
       - DB_USER=controlpanel
       - DEBUG=True
       - DJANGO_SETTINGS_MODULE=control_panel_api.settings
+      - KUBECONFIG=/home/control-panel/.kube/config
+    volumes:
+      - $HOME/.kube:/home/control-panel/.kube
   db:
     image: "circleci/postgres:9.6.2"
     environment:

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -1,0 +1,81 @@
+"use strict";
+const { assert } = require('chai');
+const { config, mock_api, url_for } = require('./conftest');
+const { api } = require('../app/k8s-api-client');
+const handlers = require('../app/tools/handlers');
+const { ModelSet } = require('../app/base-model');
+const { Deployment } = require('../app/models');
+
+
+describe('tools handler', () => {
+  const deployments_response = require('./fixtures/deployments');
+
+
+  describe('list', () => {
+
+    it('lists current user\'s tools', () => {
+      const namespace = 'user-andyhd';
+      api.namespace = namespace;
+      const url = `/k8s/apis/apps/v1beta2/namespaces/${namespace}/deployments`;
+      const expected = {
+        tools: new ModelSet(Deployment, deployments_response.items),
+      };
+
+      const api_request = mock_api()
+        .get(url)
+        .reply(200, deployments_response);
+
+      const request = new Promise((resolve, reject) => {
+        let req = {};
+        let res = {};
+        res.render = (template, data) => {
+          resolve({ template, data });
+        };
+        handlers.list(req, res, reject);
+      });
+
+      return request
+        .then(({ template, data }) => {
+          assert(api_request.isDone());
+          assert.deepEqual(data, expected);
+        });
+    });
+
+  });
+
+  describe('restart', () => {
+
+    it('restarts the specified tool', () => {
+      const namespace = 'user-andyhd';
+      api.namespace = namespace;
+      const tool = deployments_response.items[0];
+      const url = `/k8s/api/v1/namespaces/${namespace}/pods?labelSelector=app%3Drstudio`;
+
+      const get_deployment = mock_api()
+        .get(`/k8s/apis/apps/v1beta2/namespaces/${namespace}/deployments/${tool.metadata.name}`)
+        .reply(200, tool);
+      const delete_pods = mock_api()
+        .delete(url)
+        .reply(204, {});
+
+      const request = new Promise((resolve, reject) => {
+        let req = {
+          params: { id: tool.metadata.name },
+          session: { flash_messages: [] },
+        };
+        let res = {};
+        res.redirect = resolve;
+        res.render = reject;
+        handlers.restart(req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          assert(get_deployment.isDone());
+          assert(delete_pods.isDone());
+        });
+    });
+
+  });
+
+});

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -60,7 +60,7 @@ describe('tools handler', () => {
 
       const request = new Promise((resolve, reject) => {
         let req = {
-          params: { id: tool.metadata.name },
+          params: { name: tool.metadata.name },
           session: { flash_messages: [] },
         };
         let res = {};


### PR DESCRIPTION
# What

* Added tools routes and handlers for listing tools and restarting
* Added templates for listing tools

## How to review

0. Make sure you have a kubernetes config file at `$HOME/.kube/config`
1. Browse to http://localhost:3000/tools
2. See your RStudio instance listed (if you have one!)
3. Click on the `Restart` button
4. See that your RStudio instance is restarted (should get a 503 when trying to access it for a few seconds, or you can check with `kubectl get pods -n user-{your-username}`).

See [Trello #510](https://trello.com/c/wympY8SG) and [Trello #516](https://trello.com/c/EYuj7Gfs)