### PR TITLE
Add ability to deploy your RStudio instance

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -15,6 +15,10 @@ config.app = {
   asset_path: '/static/'
 };
 
+config.cluster = {
+  tools_domain: process.env.TOOLS_DOMAIN,
+};
+
 config.apps = [
   'base',
   'apps',

--- a/app/config.js
+++ b/app/config.js
@@ -1,4 +1,4 @@
-const join = require('path').join;
+const { join } = require('path');
 
 
 const config = module.exports;
@@ -7,12 +7,12 @@ const node_modules = join(__dirname, '../node_modules');
 config.api = {
   base_url: process.env.API_URL || 'http://localhost:8000',
   username: process.env.API_USER,
-  password: process.env.API_PASSWORD
+  password: process.env.API_PASSWORD,
 };
 
 config.app = {
   env: process.env.ENV || 'dev',
-  asset_path: '/static/'
+  asset_path: '/static/',
 };
 
 config.cluster = {
@@ -35,7 +35,7 @@ config.auth0 = {
   clientID: process.env.AUTH0_CLIENT_ID,
   clientSecret: process.env.AUTH0_CLIENT_SECRET,
   callbackURL: process.env.AUTH0_CALLBACK_URL || 'http://localhost:3000/callback',
-  passReqToCallback: true
+  passReqToCallback: true,
 };
 
 config.ensure_login = {
@@ -44,28 +44,28 @@ config.ensure_login = {
     /^\/error/,
     /^\/login/,
     /^\/logout/,
-    /^\/static/
-  ]
+    /^\/static/,
+  ],
 };
 
 config.express = {
   port: process.env.EXPRESS_PORT || 3000,
-  host: process.env.EXPRESS_HOST || '127.0.0.1'
+  host: process.env.EXPRESS_HOST || '127.0.0.1',
 };
 
 config.js = {
   sourceFiles: join(__dirname, 'assets/javascripts/**/*.js'),
   ignorePaths: [
-    join(__dirname, 'assets/javascripts/vendor/**/*')
+    join(__dirname, 'assets/javascripts/vendor/**/*'),
   ],
   outDir: join(__dirname, '../static/javascripts/'),
-  filename: 'app.js'
+  filename: 'app.js',
 };
 
 config.log = {
   requests: process.env.ENABLE_ACCESS_LOGS !== 'false',
   stream: process.stdout,
-  level: process.env.LOG_LEVEL || 'debug'
+  level: process.env.LOG_LEVEL || 'debug',
 };
 
 // order is important!
@@ -84,7 +84,7 @@ config.middleware = [
   'routes',
   '404',
   'raven-error-handler',
-  'errors'
+  'errors',
 ];
 
 config.repos = {
@@ -92,7 +92,7 @@ config.repos = {
   orgs: [
     'moj-analytical-services',
     'ministryofjustice',
-  ]
+  ],
 };
 
 config.sass = {
@@ -102,13 +102,13 @@ config.sass = {
       includePaths: [
         join(node_modules, 'govuk_frontend_toolkit/stylesheets'),
         join(node_modules, 'govuk_template_jinja/assets/stylesheets'),
-        join(node_modules, 'govuk-elements-sass/public/sass')
+        join(node_modules, 'govuk-elements-sass/public/sass'),
       ],
       outputStyle: 'expanded',
       sourceMap: true,
-      outDir: join(__dirname, '../static/stylesheets/')
-    }
-  ]
+      outDir: join(__dirname, '../static/stylesheets/'),
+    },
+  ],
 };
 
 config.sentry = {
@@ -116,12 +116,12 @@ config.sentry = {
   options: {
     autoBreadcrumbs: {
       console: true,
-      http: true
+      http: true,
     },
     tags: {
-      environment: process.env.ENV || 'dev'
-    }
-  }
+      environment: process.env.ENV || 'dev',
+    },
+  },
 };
 
 config.session = {
@@ -129,14 +129,14 @@ config.session = {
   secret: process.env.COOKIE_SECRET || 'shh-its-a-secret',
   resave: false,
   saveUninitialized: false,
-  logFn: console.log
+  logFn: console.log, // eslint-disable-line no-console
 };
 
 config.session_store = {
   host: process.env.REDIS_HOST || 'redis',
   port: 6379,
   logErrors: true,
-  pass: process.env.REDIS_PASSWORD
+  pass: process.env.REDIS_PASSWORD,
 };
 
 config.static = {
@@ -145,10 +145,10 @@ config.static = {
       join(__dirname, '../static'),
       join(node_modules, 'govuk_template_jinja/assets'),
       join(node_modules, 'govuk_frontend_toolkit'),
-      join(node_modules, 'jquery/dist')
+      join(node_modules, 'jquery/dist'),
     ],
     '/static/images/icons': [
-      join(node_modules, 'govuk_frontend_toolkit/images')
-    ]
-  }
+      join(node_modules, 'govuk_frontend_toolkit/images'),
+    ],
+  },
 };

--- a/app/models.js
+++ b/app/models.js
@@ -159,13 +159,12 @@ class Deployment extends K8sModel {
   }
 
   get_status() {
-    for (let condition of this.status.conditions) {
+    for (const condition of this.status.conditions) {
       if (condition.type === 'Available') {
         if (condition.status === 'True') {
           return 'Available';
-        } else {
-          return 'Unavailable';
         }
+        return 'Unavailable';
       }
     }
     return 'Unknown';
@@ -184,17 +183,17 @@ class Pod extends K8sModel {
     // based on
     // https://github.com/kubernetes/dashboard/blob/91c54261c6a3d7f601c67a2ccfbbe79f3b6a89f9/src/app/frontend/pod/list/card_component.js#L98
 
-    let containerStatus = this.data.status.containerStatuses;
+    const containerStatus = this.data.status.containerStatuses;
 
     if (containerStatus) {
-      let state = containerStatus[0].state;
+      const { state } = containerStatus[0];
 
       if (state.waiting) {
         return `Waiting: ${state.waiting.reason}`;
       }
 
       if (state.terminated) {
-        let reason = state.terminated.reason;
+        let { reason } = state.terminated;
 
         if (!reason) {
           if (state.terminated.signal) {
@@ -216,7 +215,6 @@ exports.Pod = Pod;
 
 
 class ToolDeployment {
-
   constructor(data) {
     this.tool_name = data.tool_name;
   }
@@ -228,7 +226,6 @@ class ToolDeployment {
   get endpoint() {
     return `tools/${this.tool_name}/deployments`;
   }
-
 }
 
 exports.ToolDeployment = ToolDeployment;

--- a/app/models.js
+++ b/app/models.js
@@ -1,3 +1,4 @@
+const { api } = require('./api-client');
 const { Model, ModelSet } = require('./base-model');
 const { K8sModel } = require('./k8s-model');
 
@@ -212,3 +213,22 @@ class Pod extends K8sModel {
 }
 
 exports.Pod = Pod;
+
+
+class ToolDeployment {
+
+  constructor(data) {
+    this.tool_name = data.tool_name;
+  }
+
+  create() {
+    return api.post(this.endpoint, {});
+  }
+
+  get endpoint() {
+    return `tools/${this.tool_name}/deployments`;
+  }
+
+}
+
+exports.ToolDeployment = ToolDeployment;

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -35,4 +35,10 @@
   </table>
 {% endif %}
 
+{%- if tools.length != 1 -%}
+  <form action="{{ url_for('tools.deploy', {name: 'rstudio'}) }}" method="post" class="inline-form clearfix">
+    <input type="submit" class="js-confirm button button-secondary right" value="Deploy RStudio" />
+  </form>
+{%- endif -%}
+
 {% endblock %}

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -20,11 +20,15 @@
     </thead>
     <tbody>
       {% for tool in tools %}
+
+      {%- set tool_name = tool.metadata.labels.app -%}
+      {%- set tool_url = get_tool_url(tool_name) -%}
+
       <tr>
         {% if current_user.is_superuser %}
         <td>{{ tool.metadata.namespace }}</td>
         {% endif %}
-        <td>{{ tool.metadata.labels.app }}</td>
+        <td><a target="_blank" href="{{ tool_url }}">{{ tool_name }}</a></td>
         <td>{% for pod in tool.pods %}{{ loop.index }}. {{ pod.display_status }}<br>{% endfor %}</td>
         <td class="align-right no-wrap">
           <a class="button button-secondary" href="{{ url_for('tools.restart', {name: tool.metadata.name}) }}">Restart</a>

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,4 +1,4 @@
-const { Deployment, Pod, ToolDeployment, User } = require('../models');
+const { Deployment, Pod, ToolDeployment } = require('../models');
 
 const { tools_domain } = require('../config').cluster;
 
@@ -6,7 +6,7 @@ const { tools_domain } = require('../config').cluster;
 exports.list = (req, res, next) => {
   const get_tool_url = (tool_name) => {
     return `https://${req.user.username}-${tool_name}.${tools_domain}`;
-  }
+  };
 
   Promise.all([Deployment.list(), Pod.list()])
     .then(([tools, pods]) => {
@@ -18,7 +18,7 @@ exports.list = (req, res, next) => {
       });
 
       pods.forEach((pod) => {
-        let tool = tools_lookup[pod.metadata.labels.app];
+        const tool = tools_lookup[pod.metadata.labels.app];
         if (tool) {
           tool.pods.push(pod);
         }
@@ -50,7 +50,7 @@ exports.restart = (req, res, next) => {
 exports.deploy = (req, res, next) => {
   const { url_for } = require('../routes'); // eslint-disable-line global-require
 
-  new ToolDeployment({tool_name: req.params.name}).create()
+  new ToolDeployment({ tool_name: req.params.name }).create();
 
   req.session.flash_messages.push(`Deploying '${req.params.name}'...this may take up to 5 minutes`);
   setTimeout(() => {

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -52,7 +52,7 @@ exports.deploy = (req, res, next) => {
 
   new ToolDeployment({tool_name: req.params.name}).create()
 
-  req.session.flash_messages.push(`Deploying '${req.params.name}'...`);
+  req.session.flash_messages.push(`Deploying '${req.params.name}'...this may take up to 5 minutes`);
   setTimeout(() => {
     res.redirect(url_for('tools.list'));
   }, 2000);

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,4 +1,4 @@
-const { Deployment, Pod, User } = require('../models');
+const { Deployment, Pod, ToolDeployment, User } = require('../models');
 
 
 exports.list = (req, res, next) => {
@@ -38,4 +38,16 @@ exports.restart = (req, res, next) => {
       res.redirect(url_for('tools.list'));
     })
     .catch(next);
+};
+
+
+exports.deploy = (req, res, next) => {
+  const { url_for } = require('../routes'); // eslint-disable-line global-require
+
+  new ToolDeployment({tool_name: req.params.name}).create()
+
+  req.session.flash_messages.push(`Deploying '${req.params.name}'...`);
+  setTimeout(() => {
+    res.redirect(url_for('tools.list'));
+  }, 2000);
 };

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,7 +1,13 @@
 const { Deployment, Pod, ToolDeployment, User } = require('../models');
 
+const { tools_domain } = require('../config').cluster;
+
 
 exports.list = (req, res, next) => {
+  const get_tool_url = (tool_name) => {
+    return `https://${req.user.username}-${tool_name}.${tools_domain}`;
+  }
+
   Promise.all([Deployment.list(), Pod.list()])
     .then(([tools, pods]) => {
       let tools_lookup = {};
@@ -21,7 +27,7 @@ exports.list = (req, res, next) => {
       return tools;
     })
     .then((tools) => {
-      res.render('tools/list.html', { tools });
+      res.render('tools/list.html', { tools, get_tool_url });
     })
     .catch(next);
 };

--- a/app/tools/routes.js
+++ b/app/tools/routes.js
@@ -4,4 +4,5 @@ const handlers = require('./handlers');
 module.exports = [
   { name: 'list', pattern: '/tools', handler: handlers.list },
   { name: 'restart', pattern: '/tools/:name/restart', handler: handlers.restart },
+  { name: 'deploy', method: 'POST', pattern: '/tools/:name/deploy', handler: handlers.deploy },
 ];

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -96,11 +96,11 @@ describe('tools handler', () => {
         .reply(201, {});
 
       const request = new Promise((resolve, reject) => {
-        let req = {
+        const req = {
           params: { name: tool_name },
           session: { flash_messages: [] },
         };
-        let res = {};
+        const res = {};
         res.redirect = resolve;
         res.render = reject;
         handlers.deploy(req, res, reject);
@@ -114,7 +114,5 @@ describe('tools handler', () => {
           assert(post_deployment.isDone());
         });
     });
-
   });
-
 });

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -85,4 +85,36 @@ describe('tools handler', () => {
 
   });
 
+  describe('deploy', () => {
+
+    it('deploy the specified tool for the user', function() {
+      this.timeout(2200);
+      const tool_name = 'rstudio';
+
+      const post_deployment = mock_api()
+        .post(`/tools/${tool_name}/deployments/`)
+        .reply(201, {});
+
+      const request = new Promise((resolve, reject) => {
+        let req = {
+          params: { name: tool_name },
+          session: { flash_messages: [] },
+        };
+        let res = {};
+        res.redirect = resolve;
+        res.render = reject;
+        handlers.deploy(req, res, reject);
+      });
+
+      return request
+        .then((redirect_url) => {
+          const expected_redirect_url = url_for('tools.list');
+
+          assert.equal(redirect_url, expected_redirect_url);
+          assert(post_deployment.isDone());
+        });
+    });
+
+  });
+
 });

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -43,7 +43,8 @@ describe('tools handler', () => {
         .then(({ template, data }) => {
           assert(get_deployments.isDone());
           assert(get_pods.isDone());
-          assert.deepEqual(data, expected);
+          assert.deepEqual(data.tools, expected.tools);
+          assert.typeOf(data.get_tool_url, 'function');
         });
     });
 


### PR DESCRIPTION
### What
When a user doesn't have this tool already deployed, a button to `Deploy RStudio` will be shown.

As part of these changes we now also show a link to the tool.

### Why
So that users will be able to deploy RStudio without our intervention.

### Environment variables
Before deploying we need to set the `TOOLS_DOMAIN` environment variable.

### TODO
- [x] Tests
- [x] Possibly update the `docker-compose.yaml`

### IMPORTANT: Depends on
Merge the following PRs before merging this.
- [x] https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/63
- [X] https://github.com/ministryofjustice/analytics-platform-config/pull/22

### Ticket
https://trello.com/c/BbHaXQXt/562-2-cp-app-add-node-endpoint-to-deploy-a-tool