### PR TITLE
Use ES6 for client-side JS, transpile for browser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,17 @@
 module.exports = {
   "extends": "airbnb-base",
+  "env": {
+    "browser": true,
+  },
+  "globals": {
+    "$": false,
+    "document": false,
+    "moj": true,
+    "Auth0Lock": true,
+  },
   "rules": {
     "camelcase": ["off"],
     "no-use-before-define": ["error", { "classes": false }],
-  }
+    "no-alert": 0,
+  },
 };

--- a/app/assets/javascripts/module-loader.js
+++ b/app/assets/javascripts/module-loader.js
@@ -1,39 +1,34 @@
-'use strict';
+const moj = {
 
-(function() {
-  var moj = {
+  Modules: {},
 
-    Modules: {},
+  Helpers: {},
 
-    Helpers: {},
+  Events: $({}),
 
-    Events: $({}),
-
-    init: function() {
-      var x;
-
-      for (x in moj.Modules) {
-        if (typeof moj.Modules[x].init === 'function') {
-          moj.Modules[x].init();
-        }
+  init() {
+    Object.keys(moj.Modules).forEach((key) => {
+      if (typeof moj.Modules[key].init === 'function') {
+        moj.Modules[key].init();
       }
-      // trigger initial render event
-      moj.Events.trigger('render');
-    },
+    });
 
-    // safe logging
-    log: function(msg) {
-      if (window && window.console) {
-        window.console.log(msg);
-      }
-    },
-    dir: function(obj) {
-      if (window && window.console) {
-        window.console.dir(obj);
-      }
+    moj.Events.trigger('render');
+  },
+
+  // safe logging
+  log(msg) {
+    if (window && window.console) {
+      window.console.log(msg);
     }
+  },
 
-  };
+  dir(obj) {
+    if (window && window.console) {
+      window.console.dir(obj);
+    }
+  },
 
-  window.moj = moj;
-}());
+};
+
+window.moj = moj;

--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -1,35 +1,32 @@
-'use strict';
-
 moj.Modules.auth0lock = {
   containerId: 'js-login-container',
 
-  init: function() {
-    var self = this;
+  init() {
+    const self = this;
 
-    if($('#' + self.containerId).length) {
+    if ($(`#${self.containerId}`).length) {
       self.showLock();
     }
   },
 
-  showLock: function() {
-    var self = this,
-        $el = $('#' + self.containerId),
-        clientId = $el.data('auth0-clientid'),
-        domain = $el.data('auth0-domain'),
-        callbackurl = $el.data('auth0-callbackurl'),
-        lock;
+  showLock() {
+    const self = this;
+    const $el = $(`#${self.containerId}`);
+    const clientId = $el.data('auth0-clientid');
+    const domain = $el.data('auth0-domain');
+    const callbackurl = $el.data('auth0-callbackurl');
+    const lock = new Auth0Lock(clientId, domain);
 
-    lock = new Auth0Lock(clientId, domain);
     lock.show({
       callbackURL: callbackurl,
-      responseType: "code",
+      responseType: 'code',
       authParams: {
         connection_scopes: {
-          'github': ['read:org', 'read:user', 'repo'],
+          github: ['read:org', 'read:user', 'repo'],
         },
-        scope: "openid profile offline_access"
+        scope: 'openid profile offline_access',
       },
-      container: self.containerId
+      container: self.containerId,
     });
-  }
+  },
 };

--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -2,16 +2,13 @@ moj.Modules.auth0lock = {
   containerId: 'js-login-container',
 
   init() {
-    const self = this;
-
-    if ($(`#${self.containerId}`).length) {
-      self.showLock();
+    if ($(`#${this.containerId}`).length) {
+      this.showLock();
     }
   },
 
   showLock() {
-    const self = this;
-    const $el = $(`#${self.containerId}`);
+    const $el = $(`#${this.containerId}`);
     const clientId = $el.data('auth0-clientid');
     const domain = $el.data('auth0-domain');
     const callbackurl = $el.data('auth0-callbackurl');
@@ -26,7 +23,7 @@ moj.Modules.auth0lock = {
         },
         scope: 'openid profile offline_access',
       },
-      container: self.containerId,
+      container: this.containerId,
     });
   },
 };

--- a/app/assets/javascripts/modules/bucket-name.js
+++ b/app/assets/javascripts/modules/bucket-name.js
@@ -1,11 +1,10 @@
-'use strict';
-
 moj.Modules.bucketName = {
   inputName: 'new-datasource-name',
 
-  init: function() {
-    var self = this;
-    self.$input = $('#' + self.inputName);
+  init() {
+    const self = this;
+
+    self.$input = $(`#${self.inputName}`);
 
     if (self.$input.length) {
       self.prefix = self.$input.data('bucket-prefix');
@@ -13,17 +12,17 @@ moj.Modules.bucketName = {
     }
   },
 
-  bindEvents: function() {
-    var self = this;
+  bindEvents() {
+    const self = this;
 
-    self.$input.on('keypress blur', function() {
+    self.$input.on('keypress blur', () => {
       self.formatBucketName();
     });
   },
 
-  formatBucketName: function() {
-    var self = this,
-      val = self.$input.val();
+  formatBucketName() {
+    const self = this;
+    let val = self.$input.val();
 
     if (val.length < self.prefix.length) {
       val = self.prefix;
@@ -31,5 +30,5 @@ moj.Modules.bucketName = {
 
     val = val.toLowerCase().replace(/ /gi, '-');
     self.$input.val(val);
-  }
+  },
 };

--- a/app/assets/javascripts/modules/bucket-name.js
+++ b/app/assets/javascripts/modules/bucket-name.js
@@ -2,33 +2,28 @@ moj.Modules.bucketName = {
   inputName: 'new-datasource-name',
 
   init() {
-    const self = this;
+    this.$input = $(`#${this.inputName}`);
 
-    self.$input = $(`#${self.inputName}`);
-
-    if (self.$input.length) {
-      self.prefix = self.$input.data('bucket-prefix');
-      self.bindEvents();
+    if (this.$input.length) {
+      this.prefix = this.$input.data('bucket-prefix');
+      this.bindEvents();
     }
   },
 
   bindEvents() {
-    const self = this;
-
-    self.$input.on('keypress blur', () => {
-      self.formatBucketName();
+    this.$input.on('keypress blur', () => {
+      this.formatBucketName();
     });
   },
 
   formatBucketName() {
-    const self = this;
-    let val = self.$input.val();
+    let val = this.$input.val();
 
-    if (val.length < self.prefix.length) {
-      val = self.prefix;
+    if (val.length < this.prefix.length) {
+      val = this.prefix;
     }
 
     val = val.toLowerCase().replace(/ /gi, '-');
-    self.$input.val(val);
+    this.$input.val(val);
   },
 };

--- a/app/assets/javascripts/modules/confirm.js
+++ b/app/assets/javascripts/modules/confirm.js
@@ -1,36 +1,34 @@
-'use strict';
-
 moj.Modules.jsConfirm = {
   confirmClass: 'js-confirm',
   defaultConfirmMessage: 'Are you sure?',
 
-  init: function() {
+  init() {
     this.bindEvents();
   },
 
-  bindEvents: function() {
-    var self = this;
+  bindEvents() {
+    const self = this;
 
-    $(document).on('click', 'a.' + self.confirmClass, function(e) {
-      var $el = $(e.target);
+    $(document).on('click', `a.${self.confirmClass}`, (e) => {
+      const $el = $(e.target);
       e.preventDefault();
 
-      if (confirm(self.getConfirmMessage($el))) {
+      if (window.confirm(self.getConfirmMessage($el))) {
         window.document.location = $el.attr('href');
       }
     });
 
-    $(document).on('click', 'input[type="submit"].' + self.confirmClass, function(e) {
-      var $el = $(e.target);
+    $(document).on('click', `input[type="submit"].${self.confirmClass}`, (e) => {
+      const $el = $(e.target);
       e.preventDefault();
 
-      if (confirm(self.getConfirmMessage($el))) {
+      if (window.confirm(self.getConfirmMessage($el))) {
         $el.closest('form').submit();
       }
     });
   },
 
-  getConfirmMessage: function($el) {
+  getConfirmMessage($el) {
     return $el.data('confirm-message') || this.defaultConfirmMessage;
-  }
+  },
 };

--- a/app/assets/javascripts/modules/confirm.js
+++ b/app/assets/javascripts/modules/confirm.js
@@ -7,22 +7,20 @@ moj.Modules.jsConfirm = {
   },
 
   bindEvents() {
-    const self = this;
-
-    $(document).on('click', `a.${self.confirmClass}`, (e) => {
+    $(document).on('click', `a.${this.confirmClass}`, (e) => {
       const $el = $(e.target);
       e.preventDefault();
 
-      if (window.confirm(self.getConfirmMessage($el))) {
+      if (window.confirm(this.getConfirmMessage($el))) {
         window.document.location = $el.attr('href');
       }
     });
 
-    $(document).on('click', `input[type="submit"].${self.confirmClass}`, (e) => {
+    $(document).on('click', `input[type="submit"].${this.confirmClass}`, (e) => {
       const $el = $(e.target);
       e.preventDefault();
 
-      if (window.confirm(self.getConfirmMessage($el))) {
+      if (window.confirm(this.getConfirmMessage($el))) {
         $el.closest('form').submit();
       }
     });

--- a/app/assets/javascripts/modules/flash-messages.js
+++ b/app/assets/javascripts/modules/flash-messages.js
@@ -1,17 +1,15 @@
-'use strict';
-
 moj.Modules.flashMessage = {
   messageClass: 'flash-message',
 
-  init: function() {
-    this.bindEvents()
+  init() {
+    this.bindEvents();
   },
 
-  bindEvents: function() {
-    var self = this;
+  bindEvents() {
+    const self = this;
 
-    $(document).on('click', '.' + self.messageClass, function(e) {
+    $(document).on('click', `.${self.messageClass}`, (e) => {
       $(e.target).fadeOut();
     });
-  }
+  },
 };

--- a/app/assets/javascripts/modules/flash-messages.js
+++ b/app/assets/javascripts/modules/flash-messages.js
@@ -6,9 +6,7 @@ moj.Modules.flashMessage = {
   },
 
   bindEvents() {
-    const self = this;
-
-    $(document).on('click', `.${self.messageClass}`, (e) => {
+    $(document).on('click', `.${this.messageClass}`, (e) => {
       $(e.target).fadeOut();
     });
   },

--- a/app/assets/javascripts/modules/repo-description.js
+++ b/app/assets/javascripts/modules/repo-description.js
@@ -1,5 +1,3 @@
-'use strict';
-
 moj.Modules.repoDescription = {
   repoPrefix: 'https://github.com',
   apiUrlPrefix: 'https://api.github.com/repos',
@@ -8,11 +6,12 @@ moj.Modules.repoDescription = {
   repoUrlHiddenInputName: 'repo_url',
   descriptionInputName: 'description',
 
-  init: function() {
-    var self = this;
-    self.$repoSlugSelect = $('#' + self.repoSlugSelectName);
-    self.$orgSelect = $('#' + self.orgSelectName);
-    self.$repoUrlHiddenInput = $('#' + self.repoUrlHiddenInputName);
+  init() {
+    const self = this;
+
+    self.$repoSlugSelect = $(`#${self.repoSlugSelectName}`);
+    self.$orgSelect = $(`#${self.orgSelectName}`);
+    self.$repoUrlHiddenInput = $(`#${self.repoUrlHiddenInputName}`);
 
     if (self.$repoSlugSelect.length) {
       self.bindEvents();
@@ -20,60 +19,60 @@ moj.Modules.repoDescription = {
     }
   },
 
-  bindEvents: function() {
-    var self = this;
+  bindEvents() {
+    const self = this;
 
-    self.$repoSlugSelect.on('change', function() {
-      if(self.$repoSlugSelect.val()) {
+    self.$repoSlugSelect.on('change', () => {
+      if (self.$repoSlugSelect.val()) {
         self.getRepoDescription();
       } else {
         self.updateDescription('');
         $('#repo-results').addClass('js-hidden');
       }
     });
-    self.$orgSelect.on('change', function() {
+    self.$orgSelect.on('change', () => {
       self.showOrgRepos();
     });
   },
 
-  showOrgRepos: function() {
-    var self = this;
-    var currentOrg = self.$orgSelect.val();
+  showOrgRepos() {
+    const self = this;
+    const currentOrg = self.$orgSelect.val();
 
     $('optgroup.org-repos').hide();
-    $('optgroup[label="' + currentOrg + '"]').show();
+    $(`optgroup[label="${currentOrg}"]`).show();
     self.$repoSlugSelect.find('option').eq(0).prop('selected', true);
     self.updateDescription('');
     $('#repo-results').addClass('js-hidden');
   },
 
-  getRepoDescription: function() {
-    var self = this;
-    var repoUrl = self.concatUrl(self.repoPrefix);
-    var description = self.$repoSlugSelect.find('option:selected').data('description');
+  getRepoDescription() {
+    const self = this;
+    const repoUrl = self.concatUrl(self.repoPrefix);
+    const description = self.$repoSlugSelect.find('option:selected').data('description');
 
     self.updateDescription(description);
     self.$repoUrlHiddenInput.val(repoUrl);
     $('#repo-results').removeClass('js-hidden');
   },
 
-  concatUrl: function(prefix) {
-    var self = this;
-    var org = self.$orgSelect.val();
-    var slug = self.$repoSlugSelect.val();
+  concatUrl(prefix) {
+    const self = this;
+    const org = self.$orgSelect.val();
+    const slug = self.$repoSlugSelect.val();
 
     return [prefix, org, slug].join('/');
   },
 
-  updateDescription: function(description) {
-    var self = this;
+  updateDescription(description) {
+    const self = this;
 
-    if(description) {
-      $('#' + self.descriptionInputName).val(description);
-      $('#repo-' + self.descriptionInputName).text(description);
+    if (description) {
+      $(`#${self.descriptionInputName}`).val(description);
+      $(`#repo-${self.descriptionInputName}`).text(description);
     } else {
-      $('#repo-' + self.descriptionInputName).text('None provided');
-      $('#' + self.descriptionInputName).val('');
+      $(`#repo-${self.descriptionInputName}`).text('None provided');
+      $(`#${self.descriptionInputName}`).val('');
     }
-  }
+  },
 };

--- a/app/assets/javascripts/modules/repo-description.js
+++ b/app/assets/javascripts/modules/repo-description.js
@@ -7,72 +7,63 @@ moj.Modules.repoDescription = {
   descriptionInputName: 'description',
 
   init() {
-    const self = this;
+    this.$repoSlugSelect = $(`#${this.repoSlugSelectName}`);
+    this.$orgSelect = $(`#${this.orgSelectName}`);
+    this.$repoUrlHiddenInput = $(`#${this.repoUrlHiddenInputName}`);
 
-    self.$repoSlugSelect = $(`#${self.repoSlugSelectName}`);
-    self.$orgSelect = $(`#${self.orgSelectName}`);
-    self.$repoUrlHiddenInput = $(`#${self.repoUrlHiddenInputName}`);
-
-    if (self.$repoSlugSelect.length) {
-      self.bindEvents();
-      self.showOrgRepos();
+    if (this.$repoSlugSelect.length) {
+      this.bindEvents();
+      this.showOrgRepos();
     }
   },
 
   bindEvents() {
-    const self = this;
-
-    self.$repoSlugSelect.on('change', () => {
-      if (self.$repoSlugSelect.val()) {
-        self.getRepoDescription();
+    this.$repoSlugSelect.on('change', () => {
+      if (this.$repoSlugSelect.val()) {
+        this.getRepoDescription();
       } else {
-        self.updateDescription('');
+        this.updateDescription('');
         $('#repo-results').addClass('js-hidden');
       }
     });
-    self.$orgSelect.on('change', () => {
-      self.showOrgRepos();
+    this.$orgSelect.on('change', () => {
+      this.showOrgRepos();
     });
   },
 
   showOrgRepos() {
-    const self = this;
-    const currentOrg = self.$orgSelect.val();
+    const currentOrg = this.$orgSelect.val();
 
     $('optgroup.org-repos').hide();
     $(`optgroup[label="${currentOrg}"]`).show();
-    self.$repoSlugSelect.find('option').eq(0).prop('selected', true);
-    self.updateDescription('');
+    this.$repoSlugSelect.find('option').eq(0).prop('selected', true);
+    this.updateDescription('');
     $('#repo-results').addClass('js-hidden');
   },
 
   getRepoDescription() {
-    const self = this;
-    const repoUrl = self.concatUrl(self.repoPrefix);
-    const description = self.$repoSlugSelect.find('option:selected').data('description');
+    const repoUrl = this.concatUrl(this.repoPrefix);
+    const description = this.$repoSlugSelect.find('option:selected').data('description');
 
-    self.updateDescription(description);
-    self.$repoUrlHiddenInput.val(repoUrl);
+    this.updateDescription(description);
+    this.$repoUrlHiddenInput.val(repoUrl);
     $('#repo-results').removeClass('js-hidden');
   },
 
   concatUrl(prefix) {
-    const self = this;
-    const org = self.$orgSelect.val();
-    const slug = self.$repoSlugSelect.val();
+    const org = this.$orgSelect.val();
+    const slug = this.$repoSlugSelect.val();
 
     return [prefix, org, slug].join('/');
   },
 
   updateDescription(description) {
-    const self = this;
-
     if (description) {
-      $(`#${self.descriptionInputName}`).val(description);
-      $(`#repo-${self.descriptionInputName}`).text(description);
+      $(`#${this.descriptionInputName}`).val(description);
+      $(`#repo-${this.descriptionInputName}`).text(description);
     } else {
-      $(`#repo-${self.descriptionInputName}`).text('None provided');
-      $(`#${self.descriptionInputName}`).val('');
+      $(`#repo-${this.descriptionInputName}`).text('None provided');
+      $(`#${this.descriptionInputName}`).val('');
     }
   },
 };

--- a/app/assets/javascripts/modules/tabs.js
+++ b/app/assets/javascripts/modules/tabs.js
@@ -1,16 +1,14 @@
-'use strict';
-
 moj.Modules.tabs = {
   listSelector: 'ul.tabs',
   panelSelector: 'section.tab-panel',
   activeClass: 'active',
 
-  init: function() {
-    var self = this;
+  init() {
+    const self = this;
 
     self.$list = $(self.listSelector);
 
-    if(self.$list.length) {
+    if (self.$list.length) {
       self.$tabs = self.$list.find('li');
       self.$panels = $(self.panelSelector);
 
@@ -20,22 +18,22 @@ moj.Modules.tabs = {
     }
   },
 
-  bindEvents: function() {
-    var self = this;
+  bindEvents() {
+    const self = this;
 
-    self.$list.on('click', function(e) {
+    self.$list.on('click', (e) => {
       self.selectTab($(e.target));
     });
   },
 
-  showInitialTab: function() {
-    var self = this;
-    var docHash = document.location.hash;
-    var tabIndex = 0;
+  showInitialTab() {
+    const self = this;
+    const docHash = document.location.hash;
+    let tabIndex = 0;
 
-    if(docHash.length) {
-      var checkSlug = docHash.slice(1);
-      var slugIndex = self.slugs.indexOf(checkSlug);
+    if (docHash.length) {
+      const checkSlug = docHash.slice(1);
+      const slugIndex = self.slugs.indexOf(checkSlug);
 
       if (slugIndex > 0) {
         tabIndex = slugIndex;
@@ -45,26 +43,26 @@ moj.Modules.tabs = {
     self.showTab(tabIndex);
   },
 
-  storeSlugs: function() {
-    var self = this;
+  storeSlugs() {
+    const self = this;
 
     self.slugs = [];
-    self.$tabs.each(function(x, tab) {
-      var tabSlug = encodeURIComponent($(tab).text());
+    self.$tabs.each((x, tab) => {
+      const tabSlug = encodeURIComponent($(tab).text());
 
       self.slugs.push(tabSlug);
     });
   },
 
-  selectTab: function($tab) {
-    var self = this;
-    var index = self.$tabs.index($tab);
+  selectTab($tab) {
+    const self = this;
+    const index = self.$tabs.index($tab);
 
     self.showTab(index);
   },
 
-  showTab: function(index) {
-    var self = this;
+  showTab(index) {
+    const self = this;
 
     self.$tabs.removeClass(self.activeClass);
     self.$panels.removeClass(self.activeClass);
@@ -72,5 +70,5 @@ moj.Modules.tabs = {
     self.$panels.eq(index).addClass(self.activeClass);
 
     document.location.hash = self.slugs[index];
-  }
+  },
 };

--- a/app/assets/javascripts/modules/tabs.js
+++ b/app/assets/javascripts/modules/tabs.js
@@ -4,71 +4,61 @@ moj.Modules.tabs = {
   activeClass: 'active',
 
   init() {
-    const self = this;
+    this.$list = $(this.listSelector);
 
-    self.$list = $(self.listSelector);
+    if (this.$list.length) {
+      this.$tabs = this.$list.find('li');
+      this.$panels = $(this.panelSelector);
 
-    if (self.$list.length) {
-      self.$tabs = self.$list.find('li');
-      self.$panels = $(self.panelSelector);
-
-      self.storeSlugs();
-      self.showInitialTab();
-      self.bindEvents();
+      this.storeSlugs();
+      this.showInitialTab();
+      this.bindEvents();
     }
   },
 
   bindEvents() {
-    const self = this;
-
-    self.$list.on('click', (e) => {
-      self.selectTab($(e.target));
+    this.$list.on('click', (e) => {
+      this.selectTab($(e.target));
     });
   },
 
   showInitialTab() {
-    const self = this;
     const docHash = document.location.hash;
     let tabIndex = 0;
 
     if (docHash.length) {
       const checkSlug = docHash.slice(1);
-      const slugIndex = self.slugs.indexOf(checkSlug);
+      const slugIndex = this.slugs.indexOf(checkSlug);
 
       if (slugIndex > 0) {
         tabIndex = slugIndex;
       }
     }
 
-    self.showTab(tabIndex);
+    this.showTab(tabIndex);
   },
 
   storeSlugs() {
-    const self = this;
-
-    self.slugs = [];
-    self.$tabs.each((x, tab) => {
+    this.slugs = [];
+    this.$tabs.each((x, tab) => {
       const tabSlug = encodeURIComponent($(tab).text());
 
-      self.slugs.push(tabSlug);
+      this.slugs.push(tabSlug);
     });
   },
 
   selectTab($tab) {
-    const self = this;
-    const index = self.$tabs.index($tab);
+    const index = this.$tabs.index($tab);
 
-    self.showTab(index);
+    this.showTab(index);
   },
 
   showTab(index) {
-    const self = this;
+    this.$tabs.removeClass(this.activeClass);
+    this.$panels.removeClass(this.activeClass);
+    this.$tabs.eq(index).addClass(this.activeClass);
+    this.$panels.eq(index).addClass(this.activeClass);
 
-    self.$tabs.removeClass(self.activeClass);
-    self.$panels.removeClass(self.activeClass);
-    self.$tabs.eq(index).addClass(self.activeClass);
-    self.$panels.eq(index).addClass(self.activeClass);
-
-    document.location.hash = self.slugs[index];
+    document.location.hash = this.slugs[index];
   },
 };

--- a/app/templates/includes/scripts.html
+++ b/app/templates/includes/scripts.html
@@ -3,7 +3,7 @@
 <script src="/static/javascripts/govuk/show-hide-content.js"></script>
 <script src="https://cdn.auth0.com/js/lock-9.min.js"></script>
 
-<script src="/static/javascripts/app.js"></script>
+<script src="/static/javascripts/transpiled_app.js"></script>
 <!-- initialise -->
 <script type="text/javascript">
   var showHideContent = new GOVUK.ShowHideContent();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   "homepage": "https://github.com/ministryofjustice/analytics-platform-control-panel-frontend#readme",
   "dependencies": {
     "auth0": "^2.9.1",
+    "babel-core": "^6.26.0",
+    "babel-preset-es2015": "^6.24.1",
     "body-parser": "^1.18.2",
     "bole": "3.0.2",
     "concat-files": "^0.1.1",
@@ -48,6 +50,7 @@
     "request-promise-core": "^1.1.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
     "bistre": "1.0.1",
     "chai": "^4.1.2",
     "chai-spies": "^0.7.1",


### PR DESCRIPTION
## What

Linting code is good for consistency and quality. To use the same linting engine and rules for the server-side JS and the client-side JS, they must both be written in the same dialect, i.e. ES6. This PR comprises tweaking the client-side JS to ES6 syntax and implements Babel to transpile this into ES5 code for browsers to consume. The linter can then run on the pre-transpiled ES6 code.

## How to review

1. check out and rebuild the front-end so that `npm install` is run
2. use the site normally – nothing should be apparently different
3. run `npm run lint` to see that no errors are reported from client-side code (the server-side code at time of writing reports over 400 problems – to lint just the client-side code go to `package.json` and temporarily change the lint command to point at `app/assets/javascripts` rather than `app`)

TODO: lint the server side JS and implement fixes