### PR TITLE
Show tools in tabbed home page

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -53,7 +53,7 @@ exports.create = (req, res, next) => {
         })
         .then(() => {
           const { url_for } = require('../routes'); // eslint-disable-line global-require
-          res.redirect(url_for('apps.details', { id: created_app.id }));
+          res.redirect(url_for('apps.details', { params: { id: created_app.id } }));
         });
     })
     .catch((err) => {

--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -8,7 +8,7 @@ exports.create = (req, res, next) => {
     .then(app => app.grant_bucket_access(bucket_id, 'readonly'))
     .then(() => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
-      res.redirect(url_for('apps.details', { id: app_id }));
+      res.redirect(url_for('apps.details', { params: { id: app_id } }));
     })
     .catch(next);
 };

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -34,7 +34,7 @@ exports.auth_callback = [
 
         if (!user.email_verified) {
           const { url_for } = require('../routes');
-          res.redirect(url_for('users.verify_email', {id: user.auth0_id}));
+          res.redirect(url_for('users.verify_email', { params: { id: user.auth0_id } }));
         } else {
           res.redirect(req.session.returnTo || '/');
         }

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -7,14 +7,7 @@ const raven = require('raven');
 
 
 exports.home = (req, res, next) => {
-  User.get(req.user.auth0_id)
-    .then((user) => {
-      res.render('base/home.html', {
-        signedInUser: true,
-        user,
-      });
-    })
-    .catch(next);
+  res.render('base/home.html');
 };
 
 

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -1,13 +1,19 @@
-const { api } = require('../api-client');
-const k8s = require('../k8s-api-client');
-const { User } = require('../models');
-const config = require('../config');
 const passport = require('passport');
 const raven = require('raven');
 
+const { api } = require('../api-client');
+const k8s = require('../k8s-api-client');
+const { Tool, User } = require('../models');
+const config = require('../config');
+const { get_tool_url } = require('../tools/helpers');
+
 
 exports.home = (req, res, next) => {
-  res.render('base/home.html');
+  Tool.list()
+    .then((tools) => {
+      res.render('base/home.html', { tools, get_tool_url });
+    })
+    .catch(next);
 };
 
 

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -23,7 +23,7 @@ exports.create_bucket = (req, res) => {
     .create()
     .then((bucket) => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
-      res.redirect(url_for('buckets.details', { id: bucket.id }));
+      res.redirect(url_for('buckets.details', { params: { id: bucket.id } }));
     })
     .catch((error) => {
       res.render('buckets/new.html', {

--- a/app/models.js
+++ b/app/models.js
@@ -213,6 +213,31 @@ class Pod extends K8sModel {
 
 exports.Pod = Pod;
 
+class Tool {
+  static list() {
+    return Promise
+      .all([Deployment.list(), Pod.list()])
+      .then(([tools, pods]) => {
+        const tools_lookup = {};
+
+        tools.forEach((tool) => {
+          tools_lookup[tool.metadata.labels.app] = tool;
+          tool.pods = [];
+        });
+
+        pods.forEach((pod) => {
+          const tool = tools_lookup[pod.metadata.labels.app];
+          if (tool) {
+            tool.pods.push(pod);
+          }
+        });
+
+        return tools;
+      });
+  }
+}
+
+exports.Tool = Tool;
 
 class ToolDeployment {
   constructor(data) {

--- a/app/routes.js
+++ b/app/routes.js
@@ -33,23 +33,25 @@ function add_route(route, router) {
   router[route.method](route.pattern, route.handler);
 }
 
-
-exports.url_for = function (route_name, args = {}) {
-
-  let route = routes[route_name];
+exports.url_for = function (route_name, {params = {}, fragment} = {}) {
+  const route = routes[route_name];
 
   if (!route) {
     throw new Error(`route ${route_name} not found`);
   }
 
   try {
-    return replace_route_params(route.pattern, args) + query_string(args);
+    let url = replace_route_params(route.pattern, params) + query_string(params);
 
+    if (fragment) {
+      url += '#' + encodeURIComponent(fragment);
+    }
+
+    return url;
   } catch (error) {
     throw new Error(`url_for("${route_name}") failed: ${error}`);
   }
 };
-
 
 function replace_route_params(pattern, param_values) {
 

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -32,13 +32,13 @@
       {% for userapp in app.userapps %}
         <tr>
           <td>
-            <a class="{% if current_user.auth0_id == userapp.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', {id: userapp.user.auth0_id}) }}">{{ userapp.user.name }}</a>
+            <a class="{% if current_user.auth0_id == userapp.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', { params: { id: userapp.user.auth0_id } }) }}">{{ userapp.user.name }}</a>
           </td>
           <td class="align-right">
             {% if current_user_is_app_admin %}
               <!-- Button to revoke user admin access -->
-              <form action="{{ url_for('userapps.delete', {id: userapp.id}) }}" method="post" class="inline-form clearfix">
-                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
+              <form action="{{ url_for('userapps.delete', { params: { id: userapp.id } }) }}" method="post" class="inline-form clearfix">
+                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', { params: { id: app.id } }) }}">
 
                 <input type="submit" class="js-confirm button button-secondary right" value="Revoke admin" />
               </form>
@@ -93,23 +93,23 @@
     <tbody>
       {% for apps3bucket in app.apps3buckets %}
         <tr>
-          <td><a href="{{ url_for('buckets.details', {id: apps3bucket.s3bucket.id}) }}">{{ apps3bucket.s3bucket.name }}</a></td>
+          <td><a href="{{ url_for('buckets.details', { params: { id: apps3bucket.s3bucket.id } }) }}">{{ apps3bucket.s3bucket.name }}</a></td>
           <td>{{ yes_no(apps3bucket.access_level, 'readwrite') }}</td>
           <td class="align-right">
             {% if current_user_is_app_admin %}
               <!-- Button to change access level -->
-              <form action="{{ url_for('apps3buckets.update', {id: apps3bucket.id}) }}" method="post" class="inline-form clearfix">
+              <form action="{{ url_for('apps3buckets.update', { params: { id: apps3bucket.id } }) }}" method="post" class="inline-form clearfix">
                 <input type="hidden" name="access_level" value="{{ yes_no(apps3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}">
 
-                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
+                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', { params: { id: app.id } }) }}">
 
                 <input type="submit" class="js-confirm button button-secondary right" value="{{
   yes_no(apps3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} read/write access" />
               </form>
 
               <!-- Button to revoke access -->
-              <form action="{{ url_for('apps3buckets.delete', {id: apps3bucket.id}) }}" method="post" class="inline-form clearfix">
-                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', {id: app.id}) }}">
+              <form action="{{ url_for('apps3buckets.delete', { params: { id: apps3bucket.id } }) }}" method="post" class="inline-form clearfix">
+                <input type="hidden" name="redirect_to" value="{{ url_for('apps.details', { params: { id: app.id } }) }}">
 
                 <input type="submit" class="js-confirm button button-secondary right" value="Disconnect data source" />
               </form>
@@ -146,7 +146,7 @@
 
 {% if current_user_is_app_admin %}
 <hr>
-<form action="{{ url_for('apps.delete', {id: app.id}) }}" method="post" class="clearfix">
+<form action="{{ url_for('apps.delete', { params: { id: app.id } }) }}" method="post" class="clearfix">
   <input type="submit" class="button button-warning right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
 </form>
 {% endif %}

--- a/app/templates/apps/list.html
+++ b/app/templates/apps/list.html
@@ -21,7 +21,7 @@
       {% for app in apps %}
       <tr>
         <td>{{ app.id }}</td>
-        <td><a href="{{ url_for('apps.details', {id: app.id}) }}">{{ app.name }}</a></td>
+        <td><a href="{{ url_for('apps.details', { params: { id: app.id } }) }}">{{ app.name }}</a></td>
         <td class="text">
           {% if app.description %}
             {{ app.description }}
@@ -31,8 +31,8 @@
         </td>
         <td><a href="{{ app.repo_url }}">Github</a></td>
         <td class="align-right no-wrap">
-          <a class="button button-secondary" href="{{ url_for('apps.details', {id: app.id}) }}">Manage app</a>
-          <form action="{{ url_for('apps.delete', {id: app.id}) }}" method="post" class="inline-form right clearfix">
+          <a class="button button-secondary" href="{{ url_for('apps.details', { params: { id: app.id } }) }}">Manage app</a>
+          <form action="{{ url_for('apps.delete', { params: { id: app.id } }) }}" method="post" class="inline-form right clearfix">
             <input type="submit" class="button button-warning right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
           </form>
         </td>

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -27,7 +27,8 @@
 
   <section class="tab-panel">
     <h2 class="heading-medium">Your tools</h2>
-    <a href="{{ url_for('tools.list') }}" class="button button-secondary">View your tools</a>
+
+    {% include 'tools/includes/list.html' %}
   </section>
 
   <section class="tab-panel">

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -45,7 +45,7 @@
           </thead>
           {% for users3bucket in current_user.users3buckets %}
             <tr>
-              <td><a href="{{ url_for('buckets.details', {id: users3bucket.id}) }}">{{ users3bucket.s3bucket.name }}</a></td>
+              <td><a href="{{ url_for('buckets.details', { params: { id: users3bucket.id } }) }}">{{ users3bucket.s3bucket.name }}</a></td>
               <td>
                 {{ yes_no(users3bucket.is_admin) }}
               </td>
@@ -54,8 +54,8 @@
               </td>
               <td class="align-right no-wrap">
                 {% if users3bucket.is_admin %}
-                  <a class="button button-secondary" href="{{ url_for('buckets.details', {id: users3bucket.id}) }}">Manage data source access</a>
-                  <form action="{{ url_for('buckets.delete', {id: users3bucket.id}) }}" method="post" class="inline-form">
+                  <a class="button button-secondary" href="{{ url_for('buckets.details', { params: { id: users3bucket.id } }) }}">Manage data source access</a>
+                  <form action="{{ url_for('buckets.delete', { params: { id: users3bucket.id } }) }}" method="post" class="inline-form">
                     <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
                     <input type="submit" class="button button-secondary right js-confirm" value="Delete app data source" data-confirm-message="Are you sure you want to delete this app data source?">
                   </form>
@@ -88,15 +88,15 @@
             {% for userapp in current_user.userapps %}
               <tr>
                 <td>
-                  <a href="{{ url_for('apps.details', {id: userapp.app.id}) }}">{{ userapp.app.name }}</a>
+                  <a href="{{ url_for('apps.details', { params: { id: userapp.app.id } }) }}">{{ userapp.app.name }}</a>
                 </td>
                 <td>
                   {{ yes_no(userapp.is_admin) }}
                 </td>
                 <td class="align-right">
                   {% if userapp.is_admin %}
-                    <a class="button button-secondary" href="{{ url_for('apps.details', {id: userapp.app.id}) }}">Manage app</a>
-                    <form action="{{ url_for('apps.delete', {id: userapp.app.id}) }}" method="post" class="inline-form">
+                    <a class="button button-secondary" href="{{ url_for('apps.details', { params: { id: userapp.app.id } }) }}">Manage app</a>
+                    <form action="{{ url_for('apps.delete', { params: { id: userapp.app.id } }) }}" method="post" class="inline-form">
                       <input type="submit" class="button button-secondary right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
                     </form>
                   {% endif %}

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -33,7 +33,7 @@
   <section class="tab-panel">
     <div class="form-group">
       <h2 class="heading-medium">{{ heading_prefix }} app data sources</h2>
-      {% if user.users3buckets.length %}
+      {% if current_user.users3buckets.length %}
         <table class="form-group">
           <thead>
             <tr>
@@ -43,7 +43,7 @@
               <td><span class="visuallyhidden">Actions</span></td>
             </tr>
           </thead>
-          {% for users3bucket in user.users3buckets %}
+          {% for users3bucket in current_user.users3buckets %}
             <tr>
               <td><a href="{{ url_for('buckets.details', {id: users3bucket.id}) }}">{{ users3bucket.s3bucket.name }}</a></td>
               <td>
@@ -68,28 +68,24 @@
         <p>None</p>
       {% endif %}
 
-      {% if signedInUser %}
-        <p><a class="button button-secondary" href="/buckets/new">Create new app data source</a></p>
-      {% endif %}
+      <p><a class="button button-secondary" href="/buckets/new">Create new app data source</a></p>
     </div>
   </section>
 
   <section class="tab-panel">
     <div class="form-group">
       <h2 class="heading-medium">{{ heading_prefix }} apps</h2>
-      {% if user.userapps.length %}
+      {% if current_user.userapps.length %}
         <table class="form-group">
           <thead>
             <tr>
               <th>App name</th>
               <th>User has admin access</th>
-              {% if signedInUser %}
-                <th><span class="visuallyhidden">Actions</span></th>
-              {% endif %}
+              <th><span class="visuallyhidden">Actions</span></th>
             </tr>
           </thead>
           <tbody>
-            {% for userapp in user.userapps %}
+            {% for userapp in current_user.userapps %}
               <tr>
                 <td>
                   <a href="{{ url_for('apps.details', {id: userapp.app.id}) }}">{{ userapp.app.name }}</a>
@@ -97,16 +93,14 @@
                 <td>
                   {{ yes_no(userapp.is_admin) }}
                 </td>
-                {% if signedInUser %}
-                  <td class="align-right">
-                    {% if userapp.is_admin %}
-                      <a class="button button-secondary" href="{{ url_for('apps.details', {id: userapp.app.id}) }}">Manage app</a>
-                      <form action="{{ url_for('apps.delete', {id: userapp.app.id}) }}" method="post" class="inline-form">
-                        <input type="submit" class="button button-secondary right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
-                      </form>
-                    {% endif %}
-                  </td>
-                {% endif %}
+                <td class="align-right">
+                  {% if userapp.is_admin %}
+                    <a class="button button-secondary" href="{{ url_for('apps.details', {id: userapp.app.id}) }}">Manage app</a>
+                    <form action="{{ url_for('apps.delete', {id: userapp.app.id}) }}" method="post" class="inline-form">
+                      <input type="submit" class="button button-secondary right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
+                    </form>
+                  {% endif %}
+                </td>
               </tr>
             {% endfor %}
           </tbody>
@@ -115,9 +109,7 @@
         <p>None</p>
       {% endif %}
 
-      {% if signedInUser %}
-        <p><a class="button button-secondary" href="/apps/new">Create new app</a></p>
-      {% endif %}
+      <p><a class="button button-secondary" href="/apps/new">Create new app</a></p>
     </div>
   </section>
 

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -24,22 +24,22 @@
     <tbody>
       {% for users3bucket in bucket.users3buckets %}
         <tr>
-          <td><a class="{% if current_user.auth0_id == users3bucket.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', {id: users3bucket.user.auth0_id}) }}">{{ users3bucket.user.name }}</a></td>
+          <td><a class="{% if current_user.auth0_id == users3bucket.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', { params: { id: users3bucket.user.auth0_id } }) }}">{{ users3bucket.user.name }}</a></td>
           <td>{{ yes_no(users3bucket.access_level, 'readwrite') }}</td>
           <td class="align-right">
             {% if bucket.has_admin(current_user) or current_user.is_superuser %}
               <!-- Button to change access level -->
-              <form action="{{ url_for('users3buckets.update', {id: users3bucket.id}) }}" method="post" class="inline-form clearfix">
+              <form action="{{ url_for('users3buckets.update', { params: { id: users3bucket.id } }) }}" method="post" class="inline-form clearfix">
                 <input type="hidden" name="access_level" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}" />
 
-                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}" />
+                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { params: { id: bucket.id } }) }}" />
 
                 <input type="submit" class="js-confirm button button-secondary" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} read/write access" />
               </form>
 
               <!-- Button to revoke access -->
-              <form action="{{ url_for('users3buckets.delete', {id: users3bucket.id}) }}" method="post" class="inline-form clearfix">
-                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', {id: bucket.id}) }}">
+              <form action="{{ url_for('users3buckets.delete', { params: { id: users3bucket.id } }) }}" method="post" class="inline-form clearfix">
+                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { params: { id: bucket.id } }) }}">
 
                 <input type="submit" class="js-confirm button button-secondary" value="Revoke admin access" />
               </form>
@@ -76,7 +76,7 @@
   {% endif %}
 
   <hr>
-  <form action="{{ url_for('buckets.delete', {id: bucket.id}) }}" method="post" class="clearfix">
+  <form action="{{ url_for('buckets.delete', { params: { id: bucket.id } }) }}" method="post" class="clearfix">
     <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
     <input type="submit" class="button button-warning right js-confirm" value="Delete bucket" data-confirm-message="Are you sure you want to delete this bucket?">
   </form>

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -19,10 +19,10 @@
       {% for bucket in buckets %}
         <tr>
           <td>{{ bucket.id }}</td>
-          <td><a href="{{ url_for('buckets.details', {id: bucket.id}) }}">{{ bucket.name }}</a></td>
+          <td><a href="{{ url_for('buckets.details', { params: { id: bucket.id } }) }}">{{ bucket.name }}</a></td>
           <td class="align-right">
             {% if current_user_is_bucket_admin or current_user.is_superuser %}
-              <form action="{{ url_for('buckets.delete', {id: bucket.id}) }}" method="post" class="inline-form">
+              <form action="{{ url_for('buckets.delete', { params: { id: bucket.id } }) }}" method="post" class="inline-form">
                 <input type="hidden" id="redirect" name="redirect" value="{{ url_for('buckets.list') }}">
                 <input type="submit" class="button button-secondary right js-confirm" value="Delete app data source" data-confirm-message="Are you sure you want to delete this app data source?">
               </form>

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -38,7 +38,7 @@
 
 {%- if tools.length != 1 -%}
   <form action="{{ url_for('tools.deploy', { params: { name: 'rstudio' } }) }}" method="post" class="inline-form clearfix">
-    <input type="submit" class="js-confirm button button-secondary right" value="Deploy RStudio" />
+    <input type="submit" class="button button-secondary right" value="Deploy RStudio" />
   </form>
 {%- endif -%}
 

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -1,7 +1,3 @@
-{% extends "layouts/one-column.html" %}
-
-{% set page_title = "Tools" %}
-
 {% block main_column %}
 
 <p>{{ tools.length }} tool{%- if tools.length != 1 -%}s{%- endif -%}</p>

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -31,7 +31,7 @@
         <td><a target="_blank" href="{{ tool_url }}">{{ tool_name }}</a></td>
         <td>{% for pod in tool.pods %}{{ loop.index }}. {{ pod.display_status }}<br>{% endfor %}</td>
         <td class="align-right no-wrap">
-          <a class="button button-secondary" href="{{ url_for('tools.restart', {name: tool.metadata.name}) }}">Restart</a>
+          <a class="button button-secondary" href="{{ url_for('tools.restart', { params: { name: tool.metadata.name } }) }}">Restart</a>
         </td>
       </tr>
       {% endfor %}
@@ -40,7 +40,7 @@
 {% endif %}
 
 {%- if tools.length != 1 -%}
-  <form action="{{ url_for('tools.deploy', {name: 'rstudio'}) }}" method="post" class="inline-form clearfix">
+  <form action="{{ url_for('tools.deploy', { params: { name: 'rstudio' } }) }}" method="post" class="inline-form clearfix">
     <input type="submit" class="js-confirm button button-secondary right" value="Deploy RStudio" />
   </form>
 {%- endif -%}

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -28,9 +28,10 @@
         {% if current_user.is_superuser %}
         <td>{{ tool.metadata.namespace }}</td>
         {% endif %}
-        <td><a target="_blank" href="{{ tool_url }}">{{ tool_name }}</a></td>
+        <td>{{ tool_name }}</td>
         <td>{% for pod in tool.pods %}{{ loop.index }}. {{ pod.display_status }}<br>{% endfor %}</td>
         <td class="align-right no-wrap">
+          <a class="button button-secondary" target="_blank" href="{{ tool_url }}">Open</a>
           <a class="button button-secondary" href="{{ url_for('tools.restart', { params: { name: tool.metadata.name } }) }}">Restart</a>
         </td>
       </tr>

--- a/app/templates/tools/list.html
+++ b/app/templates/tools/list.html
@@ -22,7 +22,7 @@
       {% for tool in tools %}
 
       {%- set tool_name = tool.metadata.labels.app -%}
-      {%- set tool_url = get_tool_url(tool_name) -%}
+      {%- set tool_url = get_tool_url(tool_name, current_user.username) -%}
 
       <tr>
         {% if current_user.is_superuser %}

--- a/app/templates/users/includes/tables.html
+++ b/app/templates/users/includes/tables.html
@@ -15,7 +15,7 @@
         {% for userapp in user.userapps %}
           <tr>
             <td>
-              <a href="{{ url_for('apps.details', {id: userapp.app.id}) }}">{{ userapp.app.name }}</a>
+              <a href="{{ url_for('apps.details', { params: { id: userapp.app.id } }) }}">{{ userapp.app.name }}</a>
             </td>
             <td>
               {% if userapp.is_admin %}
@@ -27,8 +27,8 @@
             {% if signedInUser %}
               <td class="align-right">
                 {% if userapp.is_admin %}
-                  <a class="button button-secondary" href="{{ url_for('apps.details', {id: userapp.app.id}) }}">Manage app</a>
-                  <form action="{{ url_for('apps.delete', {id: userapp.app.id}) }}" method="post" class="inline-form">
+                  <a class="button button-secondary" href="{{ url_for('apps.details', { params: { id: userapp.app.id } }) }}">Manage app</a>
+                  <form action="{{ url_for('apps.delete', { params: { id: userapp.app.id } }) }}" method="post" class="inline-form">
                     <input type="submit" class="button button-secondary right js-confirm" value="Delete app" data-confirm-message="Are you sure you want to delete this app?">
                   </form>
                 {% endif %}
@@ -63,7 +63,7 @@
       </thead>
       {% for users3bucket in user.users3buckets %}
         <tr>
-          <td><a href="{{ url_for('buckets.details', {id: users3bucket.s3bucket.id}) }}">{{ users3bucket.s3bucket.name }}</a></td>
+          <td><a href="{{ url_for('buckets.details', { params: { id: users3bucket.s3bucket.id } }) }}">{{ users3bucket.s3bucket.name }}</a></td>
           <td>
             {% if users3bucket.is_admin %}
               Yes
@@ -80,8 +80,8 @@
           </td>
           <td class="align-right">
             {% if users3bucket.is_admin %}
-              <a class="button button-secondary" href="{{ url_for('buckets.details', {id: users3bucket.id}) }}">Manage data source access</a>
-              <form action="{{ url_for('buckets.delete', {id: users3bucket.id}) }}" method="post" class="inline-form">
+              <a class="button button-secondary" href="{{ url_for('buckets.details', { params: { id: users3bucket.id } }) }}">Manage data source access</a>
+              <form action="{{ url_for('buckets.delete', { params: { id: users3bucket.id } }) }}" method="post" class="inline-form">
                 <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
                 <input type="submit" class="button button-secondary right js-confirm" value="Delete app data source" data-confirm-message="Are you sure you want to delete this app data source?">
               </form>

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -20,12 +20,12 @@
   <tbody>
     {% for user in users %}
       <tr>
-        <td><a class="{% if current_user.auth0_id == user.auth0_id %}highlight-current{% endif %}"" href="{{ url_for('users.details', {id: user.auth0_id}) }}">{{ user.name | default(user.username, true) }}</a></td>
+        <td><a class="{% if current_user.auth0_id == user.auth0_id %}highlight-current{% endif %}"" href="{{ url_for('users.details', { params: { id: user.auth0_id } }) }}">{{ user.name | default(user.username, true) }}</a></td>
         <td>{{ user.username }}</td>
         <td>{{ user.email }}</td>
         {% if current_user.is_superuser %}
           <td class="align-right">
-            <a class="button button-secondary" href="{{ url_for('users.edit', {id: user.auth0_id}) }}">Edit</a>
+            <a class="button button-secondary" href="{{ url_for('users.edit', { params: { id: user.auth0_id } }) }}">Edit</a>
             <a class="button button-secondary js-confirm" href="#">Delete</a>
           </td>
         {% endif %}

--- a/app/templates/users/verify_email.html
+++ b/app/templates/users/verify_email.html
@@ -5,7 +5,7 @@
 
 {% block main_column %}
 
-<form action="{{ url_for('users.verify_email', { id: user.auth0_id }) }}" method="post">
+<form action="{{ url_for('users.verify_email', { params: { id: user.auth0_id } }) }}" method="post">
 
   {{ form_field('email', 'Email', value=user.email) }}
 

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,13 +1,10 @@
 const { Deployment, Tool, ToolDeployment } = require('../models');
 
 const { tools_domain } = require('../config').cluster;
+const { get_tool_url } = require('./helpers');
 
 
 exports.list = (req, res, next) => {
-  const get_tool_url = (tool_name) => {
-    return `https://${req.user.username}-${tool_name}.${tools_domain}`;
-  };
-
   Tool.list()
     .then((tools) => {
       res.render('tools/list.html', { tools, get_tool_url });

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,6 +1,5 @@
 const { Deployment, Tool, ToolDeployment } = require('../models');
 
-const { tools_domain } = require('../config').cluster;
 const { get_tool_url } = require('./helpers');
 
 
@@ -21,7 +20,7 @@ exports.restart = (req, res, next) => {
     })
     .then(() => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
-      res.redirect(url_for('tools.list'));
+      res.redirect(url_for('base.home', { fragment: 'Analytical tools' }));
     })
     .catch(next);
 };

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,15 +1,5 @@
 const { Deployment, Tool, ToolDeployment } = require('../models');
-
 const { get_tool_url } = require('./helpers');
-
-
-exports.list = (req, res, next) => {
-  Tool.list()
-    .then((tools) => {
-      res.render('tools/list.html', { tools, get_tool_url });
-    })
-    .catch(next);
-};
 
 
 exports.restart = (req, res, next) => {
@@ -33,6 +23,6 @@ exports.deploy = (req, res, next) => {
 
   req.session.flash_messages.push(`Deploying '${req.params.name}'...this may take up to 5 minutes`);
   setTimeout(() => {
-    res.redirect(url_for('tools.list'));
+    res.redirect(url_for('base.home', { fragment: 'Analytical tools' }));
   }, 2000);
 };

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,5 +1,4 @@
-const { Deployment, Tool, ToolDeployment } = require('../models');
-const { get_tool_url } = require('./helpers');
+const { Deployment, ToolDeployment } = require('../models');
 
 
 exports.restart = (req, res, next) => {

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -1,4 +1,4 @@
-const { Deployment, Pod, ToolDeployment } = require('../models');
+const { Deployment, Tool, ToolDeployment } = require('../models');
 
 const { tools_domain } = require('../config').cluster;
 
@@ -8,24 +8,7 @@ exports.list = (req, res, next) => {
     return `https://${req.user.username}-${tool_name}.${tools_domain}`;
   };
 
-  Promise.all([Deployment.list(), Pod.list()])
-    .then(([tools, pods]) => {
-      let tools_lookup = {};
-
-      tools.forEach((tool) => {
-        tools_lookup[tool.metadata.labels.app] = tool;
-        tool.pods = [];
-      });
-
-      pods.forEach((pod) => {
-        const tool = tools_lookup[pod.metadata.labels.app];
-        if (tool) {
-          tool.pods.push(pod);
-        }
-      });
-
-      return tools;
-    })
+  Tool.list()
     .then((tools) => {
       res.render('tools/list.html', { tools, get_tool_url });
     })

--- a/app/tools/helpers.js
+++ b/app/tools/helpers.js
@@ -1,0 +1,6 @@
+const { tools_domain } = require('../config').cluster;
+
+
+exports.get_tool_url = (tool_name, username) => {
+  return `https://${username}-${tool_name}.${tools_domain}`;
+};

--- a/app/tools/routes.js
+++ b/app/tools/routes.js
@@ -2,7 +2,6 @@ const handlers = require('./handlers');
 
 
 module.exports = [
-  { name: 'list', pattern: '/tools', handler: handlers.list },
   { name: 'restart', pattern: '/tools/:name/restart', handler: handlers.restart },
   { name: 'deploy', method: 'POST', pattern: '/tools/:name/deploy', handler: handlers.deploy },
 ];

--- a/app/userapps/handlers.js
+++ b/app/userapps/handlers.js
@@ -8,7 +8,7 @@ exports.create = (req, res, next) => {
     .then(app => app.grant_user_access(user_id, 'readonly', true))
     .then(() => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
-      res.redirect(url_for('apps.details', { id: app_id }));
+      res.redirect(url_for('apps.details', { params: { id: app_id } }));
     })
     .catch(next);
 };

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -13,7 +13,7 @@ exports.create = (req, res, next) => {
     .create()
     .then(() => {
       const { url_for } = require('../routes'); // eslint-disable-line global-require
-      res.redirect(url_for('buckets.details', { id: bucket_id }));
+      res.redirect(url_for('buckets.details', { params: { id: bucket_id } }));
     })
     .catch(next);
 };

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -43,7 +43,7 @@ describe('Edit bucket form', () => {
           assert(get_app.isDone(), `Did not GET /apps/${app_id}`);
           assert(post_apps3buckets.isDone(), 'Did not POST to /apps3buckets/');
 
-          const expected_redirect_url = url_for('apps.details', { id: app_id });
+          const expected_redirect_url = url_for('apps.details', { params: { id: app_id } });
           assert.equal(redirect_url, expected_redirect_url);
         });
     });

--- a/test/test-buckets-views.js
+++ b/test/test-buckets-views.js
@@ -44,7 +44,7 @@ describe('buckets view', () => {
 
       return request
         .then((redirect_url) => {
-          assert.equal(redirect_url, url_for('buckets.details', {id: created_bucket.id}));
+          assert.equal(redirect_url, url_for('buckets.details', { params: { id: created_bucket.id } }));
         });
     });
 

--- a/test/test-login.js
+++ b/test/test-login.js
@@ -12,7 +12,7 @@ describe('Logging in', () => {
     it('fetches the API user details', () => {
       const id_token = 'test-token'
       const auth0_id = 'github|12345';
-      const next_url = url_for('users.verify_email', { id: auth0_id });
+      const next_url = url_for('users.verify_email', { params: { id: auth0_id } });
 
       const user = {
         'auth0_id': auth0_id,

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -108,7 +108,7 @@ describe('tools handler', () => {
 
       return request
         .then((redirect_url) => {
-          const expected_redirect_url = url_for('tools.list');
+          const expected_redirect_url = url_for('base.home', { fragment: 'Analytical tools' });
 
           assert.equal(redirect_url, expected_redirect_url);
           assert(post_deployment.isDone());

--- a/test/test-tool-handlers.js
+++ b/test/test-tool-handlers.js
@@ -1,56 +1,13 @@
-"use strict";
 const { assert } = require('chai');
-const { config, mock_api, url_for } = require('./conftest');
+const { mock_api, url_for } = require('./conftest');
 const { api } = require('../app/k8s-api-client');
 const handlers = require('../app/tools/handlers');
-const { ModelSet } = require('../app/base-model');
-const { Deployment, Pod } = require('../app/models');
 
 
 describe('tools handler', () => {
-  const deployments_response = require('./fixtures/deployments');
-  const pods_response = require('./fixtures/deployment-pods');
-
-  describe('list', () => {
-
-    it('lists current user\'s tools', () => {
-      const namespace = 'user-andyhd';
-      const expected = {
-        tools: new ModelSet(Deployment, deployments_response.items),
-      };
-      expected.tools[0].pods = new ModelSet(Pod, pods_response.items);
-
-      const get_deployments = mock_api()
-        .get(`/k8s/apis/apps/v1beta2/namespaces/${namespace}/deployments`)
-        .reply(200, deployments_response);
-
-      const get_pods = mock_api()
-        .get(`/k8s/api/v1/namespaces/${namespace}/pods`)
-        .reply(200, pods_response);
-
-      api.namespace = namespace;
-
-      const request = new Promise((resolve, reject) => {
-        let req = {};
-        let res = {};
-        res.render = (template, data) => {
-          resolve({ template, data });
-        };
-        handlers.list(req, res, reject);
-      });
-
-      return request
-        .then(({ template, data }) => {
-          assert(get_deployments.isDone());
-          assert(get_pods.isDone());
-          assert.deepEqual(data.tools, expected.tools);
-          assert.typeOf(data.get_tool_url, 'function');
-        });
-    });
-
-  });
 
   describe('restart', () => {
+    const deployments_response = require('./fixtures/deployments');
 
     it('restarts the specified tool', () => {
       const namespace = 'user-andyhd';

--- a/test/test-tool-model.js
+++ b/test/test-tool-model.js
@@ -1,0 +1,37 @@
+const { assert } = require('chai');
+const { mock_api } = require('./conftest');
+const { api } = require('../app/k8s-api-client');
+const { ModelSet } = require('../app/base-model');
+const { Deployment, Pod, Tool } = require('../app/models');
+
+
+describe('Tool model', () => {
+  const deployments_response = require('./fixtures/deployments');
+  const pods_response = require('./fixtures/deployment-pods');
+
+  describe('list()', () => {
+    it('lists current user\'s tools', () => {
+      const namespace = 'user-andyhd';
+
+      const get_deployments = mock_api()
+        .get(`/k8s/apis/apps/v1beta2/namespaces/${namespace}/deployments`)
+        .reply(200, deployments_response);
+
+      const get_pods = mock_api()
+        .get(`/k8s/api/v1/namespaces/${namespace}/pods`)
+        .reply(200, pods_response);
+
+      api.namespace = namespace;
+
+      Tool.list()
+        .then((tools) => {
+          const expected_tools = new ModelSet(Deployment, deployments_response.items);
+          expected_tools[0].pods = new ModelSet(Pod, pods_response.items);
+          assert.deepEqual(tools, expected_tools);
+
+          assert(get_deployments.isDone());
+          assert(get_pods.isDone());
+        });
+    });
+  });
+});

--- a/test/test-users3buckets-create.js
+++ b/test/test-users3buckets-create.js
@@ -42,7 +42,7 @@ describe('Edit bucket form', () => {
         .then((redirect_url) => {
           assert(post_users3buckets.isDone(), 'Did not make POST request to API endpoint /users3buckets/ as expected');
 
-          const expected_redirect_url = url_for('buckets.details', {id: bucket_id});
+          const expected_redirect_url = url_for('buckets.details', { params: { id: bucket_id } });
           assert.equal(redirect_url, expected_redirect_url);
         });
     });


### PR DESCRIPTION
### What
The main aim of this is to display the list of tools directly in the new tabbed home without having to click around.

#### Other UX improvements include
 - Added "Open" button for tools as the link wasn't explicit enough for the users
 - Don't ask for confirmation when deploying RStudio. It's not a destructive operation so no point in asking.
 - Support for redirect to specific tab of new homepage
 - Removed `GET /tools` view

#### Internal refactoring
 - Added `Tool` model with `Tool.list` to not have logic to get k8s deployments/pods directly in route handler
 - Added support for [fragments](https://en.wikipedia.org/wiki/Fragment_identifier) (the part after the `#` in an URL) in `routes.url_for()`
   - All existing client code is updated but worth watch out for anything I missed
 - Removed `GET /tools` route/handler
 - Moved tools' `list.html` under `/app/templates/includes/list.html` for use in other views (for now it's only used in the home but we may want to render the list of tools in other places)
 - Moved `get_tool_url()` in `tools/helpers` module instead of having it directly in the route handler code
 - Don't make unnecessary request to get current user in home route handler and don't pass unnecessary locals, just use `current_user` which is already available.
    - For example `signedInUser` was passed always as `true` so I removed few unnecessary `if` statements
 - More linting love

### Notable changes

In order to support fragment I had to change the function signature and update all the client code.

Before:
`url_for('buckets.details', { id: bucket_id })`

Now:
`url_for('buckets.details', { params:  { id: bucket_id } })`

To get the URL with the fragment part you can pass the `fragment` argument:
`url_for('base.home', { fragment: 'Analytical tools' })`



### How to review

1. Start the thing
2. Click around
3. Check things are working as expected
4. Sell some bitcoins
5. Profit!

### Ticket
https://trello.com/c/rp8rfsWy/568-3-refactor-for-tools-tab-in-homepage