### PR TITLE
Tell Python not to buffer output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - DEBUG=True
       - DJANGO_SETTINGS_MODULE=control_panel_api.settings
       - KUBECONFIG=/home/control-panel/.kube/config
+      - PYTHONUNBUFFERED=1
     volumes:
       - $HOME/.kube:/home/control-panel/.kube
   db:


### PR DESCRIPTION
May be a fix for not seeing `print()` output from the API when running docker-compose
