### PR TITLE
Snappied RStudio deploy

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -9,9 +9,12 @@ const { get_tool_url } = require('../tools/helpers');
 
 
 exports.home = (req, res, next) => {
+  const rstudio_is_deploying = req.session.rstudio_is_deploying;
+  req.session.rstudio_is_deploying = false;
+
   Tool.list()
     .then((tools) => {
-      res.render('base/home.html', { tools, get_tool_url });
+      res.render('base/home.html', { tools, get_tool_url, rstudio_is_deploying });
     })
     .catch(next);
 };

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -1,20 +1,20 @@
 {% block main_column %}
 
-<p>{{ tools.length }} tool{%- if tools.length != 1 -%}s{%- endif -%}</p>
+<p>Please refresh your browser to update the status of your tools.</p>
 
-{% if tools.length %}
-  <table class="form-group list">
-    <thead>
-      <tr>
-        {% if current_user.is_superuser %}
-        <th>Namespace</th>
-        {% endif %}
-        <th>Name</th>
-        <th>Status</th>
-        <th><span class="visuallyhidden">Actions</span></th>
-      </tr>
-    </thead>
-    <tbody>
+<table class="form-group list">
+  <thead>
+    <tr>
+      {% if current_user.is_superuser %}
+        </s><th>Namespace</th>
+      {% endif %}
+      <th>Name</th>
+      <th>Status</th>
+      <th><span class="visuallyhidden">Actions</span></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if tools.length %}
       {% for tool in tools %}
 
       {%- set tool_name = tool.metadata.labels.app -%}
@@ -32,14 +32,27 @@
         </td>
       </tr>
       {% endfor %}
+    {% else %}
+      {% if current_user.is_superuser %}
+        <td>user-{{ current_user.username }}</td>
+      {% endif %}
+      <td>RStudio</td>
+      <td>
+        {% if rstudio_is_deploying %}
+          Deploying
+        {% else %}
+          Not deployed
+        {% endif %}
+      </td>
+      <td class="align-right no-wrap">
+        {% if not rstudio_is_deploying %}
+          <form action="{{ url_for('tools.deploy', { params: { name: 'rstudio' } }) }}" method="post" class="inline-form clearfix">
+            <input type="submit" class="button button-secondary right" value="Deploy" />
+          </form>
+        {% endif %}
+      </td>
+    {% endif %}
     </tbody>
   </table>
-{% endif %}
-
-{%- if tools.length != 1 -%}
-  <form action="{{ url_for('tools.deploy', { params: { name: 'rstudio' } }) }}" method="post" class="inline-form clearfix">
-    <input type="submit" class="button button-secondary right" value="Deploy RStudio" />
-  </form>
-{%- endif -%}
 
 {% endblock %}

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -20,8 +20,8 @@ exports.deploy = (req, res, next) => {
 
   new ToolDeployment({ tool_name: req.params.name }).create();
 
+  req.session.rstudio_is_deploying = true;
   req.session.flash_messages.push(`Deploying '${req.params.name}'...this may take up to 5 minutes`);
-  setTimeout(() => {
-    res.redirect(url_for('base.home', { fragment: 'Analytical tools' }));
-  }, 2000);
+
+  res.redirect(url_for('base.home', { fragment: 'Analytical tools' }));
 };


### PR DESCRIPTION
#### What

- Removed delay after clicking "Deploy", user is redirected straight away
- Show the non-deployed RStudio tool in the table of tools
- When RStudio is not deployed show the "Deploy" button as an action
- After the user click on "Deploy" we set `rstudio_is_deploying` in the
  session so we show "Deploying" in its status and we hide the "Deploy"
  button

#### NOTE

This is based on the `ag-tool-model` branch at the moment which is [under review here](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/93).
#### Ticket

https://trello.com/c/ZLa2RCfo/569-2-remove-2-second-delay-from-deploy-r-studio