### PR TITLE
Show repo descriptions without AJAX

### DIFF
--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -29,10 +29,11 @@
     </select>
     <span>/</span>
     <select name="name" id="name" class="form-control form-control-1-3">
+      <option value="">Select repo...</option>
       {% for org, repos in repos | groupby("org") %}
-        <optgroup label="{{ org }}">
+        <optgroup label="{{ org }}" class="org-repos">
           {% for repo in repos | sort(false, false, "name") %}
-          <option value="{{ repo.name }}">{{ repo.name }}</option>
+            <option value="{{ repo.name }}" data-description="{{ repo.description }}">{{ repo.name }}</option>
           {% endfor %}
         </optgroup>
       {% endfor %}
@@ -41,22 +42,10 @@
 
   <input type="hidden" id="repo_url" name="repo_url" value="{{ app.repo_url }}">
 
-  <div id="repo-check" class="form-group js-hidden">
-    <div id="repo-checking" class="js-hidden">
-      <div class="spinner">
-        <div class="rect1"></div>
-        <div class="rect2"></div>
-        <div class="rect3"></div>
-        <div class="rect4"></div>
-        <div class="rect5"></div>
-      </div>
-      <p></p>
-    </div>
-    <div id="repo-results" class="js-hidden panel text">
-      <h3 class="heading-small">Description:</h3>
-      <span id="repo-description"></span>
-      <input type="hidden" name="description" id="description" value="">
-    </div>
+  <div id="repo-results" class="js-hidden panel text">
+    <h3 class="heading-small">Description:</h3>
+    <span id="repo-description"></span>
+    <input type="hidden" name="description" id="description" value="">
   </div>
 
 


### PR DESCRIPTION
## What

Now that the repos and orgs are being fetched by the node app, there is no need to try and get the repo descriptions via AJAX. This now shows the repo description when a repo is selected, or "None provided" if there isn't one.

Also the second dropdown only lists the repos that match the org selected in the first dropdown.

A later piece of work will implement type-ahead instead of the second dropdown.

## How to review

1. check out and run
2. go to create a new app
3. see that the org dropdown changes the content of the repo dropdown
4. see that when selecting a repo from the repo dropdown, the description is updated
5. if a new app is created from a repo that has a description, the app has that description also

TODO: 
* replace second dropdown with JS-powered type-ahead
* put a button on the app details/edit page to update the description from github?