### PR TITLE
Only show Tools tab to non superusers

### DIFF
--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -10,8 +10,10 @@
       <li>Superuser</li>
     {% endif %}
     <li>Analytical tools</li>
-    <li>Data</li>
-    <li>Webapps</li>
+    {% if current_user.is_superuser %}
+      <li>Data</li>
+      <li>Webapps</li>
+    {% endif %}
   </ul>
 
   {% if current_user.is_superuser %}


### PR DESCRIPTION
[Trello](https://trello.com/c/vjEufKxA/571-only-show-users-analytical-tools-tab-until-the-other-ones-actually-work-for-them-1)

## What

The 'data' and 'webapps' tabs are no use to anyone until we have user perms, so hide them.

## How to review

1. Review