### PR TITLE
Never return a falsy value from 'set'

### DIFF
--- a/app/api_clients/github.js
+++ b/app/api_clients/github.js
@@ -1,6 +1,7 @@
 const config = require('../config');
 const GithubAPI = require('github');
 const { ManagementClient } = require('auth0');
+const { User } = require('../models');
 
 
 class GithubAPIClient extends GithubAPI {
@@ -26,8 +27,10 @@ class GithubAPIClient extends GithubAPI {
 
       return management.getUser({ id: user.auth0_id })
         .then((profile) => {
-          user.github_access_token = profile.identities[0].access_token;
-          return user.github_access_token;
+          const updated_user = new User(Object.assign(user.data, {
+            github_access_token: profile.identities[0].access_token
+          }));
+          return updated_user.github_access_token;
         });
     }
 

--- a/app/models/base.js
+++ b/app/models/base.js
@@ -16,7 +16,8 @@ const model_proxy = {
     if (Reflect.has(model, property)) {
       return Reflect.set(model, property, value);
     }
-    return model.data[property] = value;
+    model.data[property] = value;
+    return true;
   }
 };
 


### PR DESCRIPTION
## What

The error message `'set' on proxy: trap returned falsish for property 'github_access_token'` was shown on the create app page.

This error is thrown when the `User.github_access_token` is set in the Github API client code. This may be masking another error.