### PR TITLE
Fix bug where Kubernetes API calls all use default namespace

### DIFF
--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -1,5 +1,6 @@
 const { APIError } = require('../api_clients/base');
 const { api } = require('../api_clients/control_panel_api');
+const { get_namespace } = require('../api_clients/kubernetes');
 const base = require('./base');
 
 
@@ -203,6 +204,10 @@ class User extends Model {
 
   get users3buckets() {
     return new ModelSet(UserS3Bucket, this.data.users3buckets);
+  }
+
+  get kubernetes_namespace() {
+    return get_namespace(this.data.username);
   }
 }
 

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -5,9 +5,6 @@
 <table class="form-group list">
   <thead>
     <tr>
-      {% if current_user.is_superuser %}
-        </s><th>Namespace</th>
-      {% endif %}
       <th>Name</th>
       <th>Status</th>
       <th><span class="visuallyhidden">Actions</span></th>
@@ -21,9 +18,6 @@
       {%- set tool_url = get_tool_url(tool_name, current_user.username) -%}
 
       <tr>
-        {% if current_user.is_superuser %}
-        <td>{{ tool.metadata.namespace }}</td>
-        {% endif %}
         <td>{{ tool_name }}</td>
         <td>{% for pod in tool.pods %}{{ loop.index }}. {{ pod.display_status }}<br>{% endfor %}</td>
         <td class="align-right no-wrap">
@@ -33,9 +27,6 @@
       </tr>
       {% endfor %}
     {% else %}
-      {% if current_user.is_superuser %}
-        <td>user-{{ current_user.username }}</td>
-      {% endif %}
       <td>RStudio</td>
       <td>
         {% if rstudio_is_deploying %}


### PR DESCRIPTION
## What

Listing users' tools either fails because they do not have permission to access outside their own namespace, or superusers see all deployments and pods.

This is because of a bug where the Kubernetes namespace is not set to the user's own prior to making a request.

Unfortunately, this fix is not observable for non-superusers in dev, because RBAC is enabled and most users do not have admin rights on their own namespace.