### PR TITLE
Repo typeahead

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -21,7 +21,7 @@ exports.new = (req, res, next) => {
 
 exports.create = (req, res, next) => {
   const app = new App({
-    name: req.body.name,
+    name: req.body.repo_typeahead,
     description: req.body.description,
     repo_url: req.body.repo_url,
     userapps: [],

--- a/app/assets/javascripts/modules/repo-description.js
+++ b/app/assets/javascripts/modules/repo-description.js
@@ -5,7 +5,7 @@ moj.Modules.repoDescription = {
   repoSlugTypeaheadName: 'repo_typeahead',
   repoUrlHiddenInputName: 'repo_url',
   descriptionInputName: 'description',
-  repoSelected: null,
+  repoSelected: false,
 
   init() {
     this.$repoSlugSelect = $(`#${this.repoSlugSelectName}`);
@@ -31,14 +31,8 @@ moj.Modules.repoDescription = {
     const repos = repoOptions.map(opt => opt.text);
     const descriptions = repoOptions.map(opt => opt.dataset.description);
 
-    // reset potentially pre-existing typeahead
-    this.repoSelected = false;
-    this.$repoSlugSelect.hide();
-    this.$repoSlugTypeahead.val('');
-    $('.typeahead__result, .typeahead__cancel-button').remove();
-    $('.typeahead__container').removeClass('cancel');
+    this.resetTypeahead();
 
-    // initialise repo-typeahead for selected org
     this.$repoSlugTypeahead.typeahead({
       order: 'asc',
       maxItem: 0,
@@ -53,20 +47,20 @@ moj.Modules.repoDescription = {
           this.repoSelected = true;
         },
         onCancel: () => {
-          this.updateDescription('');
-          $('#repo-results').addClass('js-hidden');
-          this.repoSelected = false;
+          this.resetTypeahead();
         },
-        onSubmit: () => {
-          if (!this.repoSelected) {
-            return false;
-          }
-          return true;
-        },
+        onSubmit: () => this.repoSelected,
       },
     });
+  },
 
+  resetTypeahead() {
+    this.repoSelected = false;
+    this.$repoSlugSelect.hide();
+    this.$repoSlugTypeahead.val('');
     this.updateDescription('');
+    $('.typeahead__result, .typeahead__cancel-button').remove();
+    $('.typeahead__container').removeClass('cancel');
     $('#repo-results').addClass('js-hidden');
   },
 

--- a/app/assets/sass/app.scss
+++ b/app/assets/sass/app.scss
@@ -25,3 +25,4 @@ $path: "/static/images/";
 @import 'local/spinner';
 @import 'local/utilities';
 @import 'local/debug';
+@import 'local/typeahead';

--- a/app/assets/sass/local/typeahead.scss
+++ b/app/assets/sass/local/typeahead.scss
@@ -1,0 +1,11 @@
+.typeahead__container {
+  display: inline-block;
+  width: 33.33%;
+  @include core-16;
+}
+
+.typeahead__field {
+  input {
+    border: 2px solid $black;
+  }
+}

--- a/app/config.js
+++ b/app/config.js
@@ -151,6 +151,7 @@ config.static = {
       join(node_modules, 'govuk_template_jinja/assets'),
       join(node_modules, 'govuk_frontend_toolkit'),
       join(node_modules, 'jquery/dist'),
+      join(node_modules, 'jquery-typeahead/dist'),
     ],
     '/static/images/icons': [
       join(node_modules, 'govuk_frontend_toolkit/images'),

--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -28,6 +28,15 @@
       {% endfor %}
     </select>
     <span>/</span>
+
+    <div class="typeahead__container">
+      <div class="typeahead__field">
+        <span class="typeahead__query">
+          <input id="repo_typeahead" class="form-control form-control-1-2" name="repo_typeahead" type="search" autocomplete="off" placeholder="Start typing to search...">
+        </span>
+      </div>
+    </div>
+
     <select name="name" id="name" class="form-control form-control-1-3">
       <option value="">Select repo...</option>
       {% for org, repos in repos | groupby("org") %}

--- a/app/templates/includes/head.html
+++ b/app/templates/includes/head.html
@@ -1,2 +1,3 @@
+<link rel="stylesheet" href="/static/jquery.typeahead.min.css" type="text/css">
 <!--[if lte IE 8]><link href="/static/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/static/stylesheets/app.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/templates/includes/scripts.html
+++ b/app/templates/includes/scripts.html
@@ -1,5 +1,6 @@
 <!-- Javascript -->
 <script src="/static/jquery.min.js"></script>
+<script src="/static/jquery.typeahead.min.js"></script>
 <script src="/static/javascripts/govuk/show-hide-content.js"></script>
 <script src="https://cdn.auth0.com/js/lock-9.min.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "govuk_frontend_toolkit": "7.0.0",
     "govuk_template_jinja": "0.22.1",
     "jquery": "^3.2.1",
+    "jquery-typeahead": "^2.10.4",
     "morgan": "^1.9.0",
     "node-sass": "^4.5.3",
     "nunjucks": "3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,7 +2373,14 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-jquery@^3.2.1:
+jquery-typeahead@^2.10.4:
+  version "2.10.4"
+  resolved "https://registry.yarnpkg.com/jquery-typeahead/-/jquery-typeahead-2.10.4.tgz#9a46d74fda419b0724ae0ff3663f800d280bc6ce"
+  dependencies:
+    jquery ">=1.7.2"
+    lz-string "^1.4.4"
+
+jquery@>=1.7.2, jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
@@ -2640,6 +2647,10 @@ lru-memoizer@^1.11.1:
 lsmod@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lsmod/-/lsmod-1.0.0.tgz#9a00f76dca36eb23fa05350afe1b585d4299e64b"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
 
 make-dir@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What

When adding a new app to link to some data, it is necessary to link an existing repo from one of the allowed github orgs. This means a long dropdown with ~100 entries at the moment. Implementing a typeahead should make it easier to find a repo from the specified pool.

## How to review

1. check out, rebuild, run
2. create a new app
3. see that where there was previously a dropdown listing repos, there is now a typeahead search box.

Before
---
![image](https://user-images.githubusercontent.com/988436/34878210-4caa7994-f7a1-11e7-8f3d-b30e0f34a303.png)


After
---
![image](https://user-images.githubusercontent.com/988436/34878181-2ffcd026-f7a1-11e7-8750-775e09caed3a.png)
