### PR TITLE
migrate auth0 lock from v9 to v11.0.1

### DIFF
--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -12,18 +12,36 @@ moj.Modules.auth0lock = {
     const clientId = $el.data('auth0-clientid');
     const domain = $el.data('auth0-domain');
     const callbackurl = $el.data('auth0-callbackurl');
-    const lock = new Auth0Lock(clientId, domain);
-
-    lock.show({
-      callbackURL: callbackurl,
-      responseType: 'code',
-      authParams: {
-        connection_scopes: {
+    const lockOptions = {
+      allowedConnections: ['github'],
+      auth: {
+        connectionScopes: {
           github: ['read:org', 'read:user', 'repo'],
         },
-        scope: 'openid profile offline_access',
+        params: {
+          scope: 'openid profile offline_access',
+        },
+        responseType: 'code',
+        redirectUrl: callbackurl,
       },
       container: this.containerId,
-    });
+      theme: {
+        logo: '/static/images/gov.uk_logotype_crown.svg',
+        primaryColor: '#000000',
+        authButtons: {
+          github: {
+            primaryColor: '#efefef',
+            foregroundColor: '#000000',
+          },
+        },
+      },
+      languageDictionary: {
+        title: 'Log in',
+      },
+      rememberLastLogin: true,
+    };
+    const lock = new Auth0Lock(clientId, domain, lockOptions);
+
+    lock.show();
   },
 };

--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -1,5 +1,31 @@
 moj.Modules.auth0lock = {
   containerId: 'js-login-container',
+  config: {
+    allowedConnections: ['github'],
+    auth: {
+      connectionScopes: {
+        github: ['read:org', 'read:user', 'repo'],
+      },
+      params: {
+        scope: 'openid profile offline_access',
+      },
+      responseType: 'code',
+    },
+    theme: {
+      logo: '/static/images/gov.uk_logotype_crown.svg',
+      primaryColor: '#000000',
+      authButtons: {
+        github: {
+          primaryColor: '#efefef',
+          foregroundColor: '#000000',
+        },
+      },
+    },
+    languageDictionary: {
+      title: 'Log in',
+    },
+    rememberLastLogin: true,
+  },
 
   init() {
     if ($(`#${this.containerId}`).length) {
@@ -8,39 +34,13 @@ moj.Modules.auth0lock = {
   },
 
   showLock() {
+    const lockConfig = this.config;
     const $el = $(`#${this.containerId}`);
     const clientId = $el.data('auth0-clientid');
     const domain = $el.data('auth0-domain');
-    const callbackurl = $el.data('auth0-callbackurl');
-    const lockOptions = {
-      allowedConnections: ['github'],
-      auth: {
-        connectionScopes: {
-          github: ['read:org', 'read:user', 'repo'],
-        },
-        params: {
-          scope: 'openid profile offline_access',
-        },
-        responseType: 'code',
-        redirectUrl: callbackurl,
-      },
-      container: this.containerId,
-      theme: {
-        logo: '/static/images/gov.uk_logotype_crown.svg',
-        primaryColor: '#000000',
-        authButtons: {
-          github: {
-            primaryColor: '#efefef',
-            foregroundColor: '#000000',
-          },
-        },
-      },
-      languageDictionary: {
-        title: 'Log in',
-      },
-      rememberLastLogin: true,
-    };
-    const lock = new Auth0Lock(clientId, domain, lockOptions);
+    lockConfig.container = this.containerId;
+    lockConfig.auth.redirectUrl = $el.data('auth0-callbackurl');
+    const lock = new Auth0Lock(clientId, domain, lockConfig);
 
     lock.show();
   },

--- a/app/assets/sass/local/login.scss
+++ b/app/assets/sass/local/login.scss
@@ -1,103 +1,17 @@
-#a0-lock * {
-  -webkit-animation: none !important;
-  animation: none !important;
-  -webkit-transition: none !important;
-  transition: none !important;
-}
-
 .login-container {
   padding-top: 4em;
 
-  #a0-lock.a0-theme-default {
-
-    .a0-bg-gradient {
-      display: none;
-    }
-
-    .a0-panel {
-      margin: 0;
-      width: auto;
-      -webkit-box-shadow: none;
-      box-shadow: none;
-      border: none;
-      text-align: left;
-
-      * {
-        font-family: "nta", Arial, sans-serif;
-        font-stretch: normal;
-        color: $black;
-      }
-
-      .a0-mode {
-        form {
-          .a0-body-content {
-            padding: 0 0 30px 0;
-          }
-        }
-      }
-
-      .a0-icon-container {
-        min-height: 0;
-
-        .a0-image {
-          display: none;
-          background-image: url(/static/images/gov.uk_logotype_crown_invert_trans.png);
-          background-size: 72px 64px;
-          background-repeat: no-repeat;
-          background-position: center center;
-          height: 80px;
-
-          img {
-            display: none;
-          }
-        }
-      }
-
-      .a0-top-header {
-        min-height: 0;
-
-        h1 {
-          @include heading-36;
-          padding: 0;
-          margin: 0 0 30px 0;
-        }
-      }
-
-      .a0-mode-container {
-        .a0-loggedin {
-          text-align: left;
-        }
-
-        .a0-zocial {
-          border: none;
-          border-radius: 0;
-          background: #eee;
-          opacity: 1;
-
-          &:hover {
-            background: #e4e4e4;
-
-            span {
-              background: none;
-            }
-          }
-
-          span {
-            @include core-16(40px, 40px);
-            text-transform: none;
-          }
-
-          &:before {
-            width: 40px;
-          }
-        }
-      }
-
-      .a0-last-time,
-      .a0-all {
-        @include core-16;
-        color: $black;
-      }
-    }
+  * {
+    font-family: $nta-light !important;
   }
+}
+
+
+// overrides - could stop working in future versions of lock, but aren't crucial
+.auth0-lock-center {
+  border: 1px solid $grey-3;
+  border-radius: 5px;
+}
+.auth0-lock-social-button-text {
+  font-weight: 400 !important;
 }

--- a/app/templates/includes/scripts.html
+++ b/app/templates/includes/scripts.html
@@ -2,7 +2,7 @@
 <script src="/static/jquery.min.js"></script>
 <script src="/static/jquery.typeahead.min.js"></script>
 <script src="/static/javascripts/govuk/show-hide-content.js"></script>
-<script src="https://cdn.auth0.com/js/lock-9.min.js"></script>
+<script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>
 
 <script src="/static/javascripts/transpiled_app.js"></script>
 <!-- initialise -->

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,11 +4,7 @@
 
   <main id="content" role="main">
 
-    <div class="grid-row">
-      <div class="column-one-half">
-        <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"></div>
-      </div>
-    </div>
+    <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"><p>Init login...</p></div>
 
   </main>
 


### PR DESCRIPTION
## What

Auth0 are deprecating all versions of lock prior to 11. This moves us up to the latest version of `lock.js`. One thing to note is that post v9, theming is longer used and CSS overrides are discouraged due to the possibility of breaking in subsequent versions. This PR applies minimal styling (logo, button colours) using the prescribed methods and very minimal CSS overrides which are non-crucial but improve the look slightly for now.

## How to review

1. Check out and run
2. See the login page look like this:
<img width="979" alt="screen shot 2018-01-16 at 11 18 33" src="https://user-images.githubusercontent.com/988436/34987148-0baef0a0-fab2-11e7-9070-57c6a297c3be.png">
