### PR TITLE
Fix login with Auth0 Lock v11

### DIFF
--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -40,6 +40,7 @@ moj.Modules.auth0lock = {
     const domain = $el.data('auth0-domain');
     lockConfig.container = this.containerId;
     lockConfig.auth.redirectUrl = $el.data('auth0-callbackurl');
+    lockConfig.auth.state = $el.data('auth0-state');
     const lock = new Auth0Lock(clientId, domain, lockConfig);
 
     lock.show();

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -5,6 +5,7 @@ const config = require('../config');
 const passport = require('passport');
 const raven = require('raven');
 const { get_tool_url } = require('../tools/helpers');
+const uuid = require('uuid');
 
 
 exports.home = (req, res, next) => {
@@ -57,9 +58,12 @@ exports.auth_callback = [
 ];
 
 exports.login = (req, res) => {
+  const state = uuid();
+  req.session[config.auth0.sessionKey] = { state };
   res.render('login.html', {
     env: process.env,
     session: req.session,
+    state,
   });
 };
 

--- a/app/config.js
+++ b/app/config.js
@@ -35,6 +35,7 @@ config.auth0 = {
   clockTolerance: 10,
   timeout: 5000,
   retries: 2,
+  sessionKey: `oidc:${process.env.AUTH0_DOMAIN}`,
 };
 
 config.babel = {

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -24,6 +24,7 @@ Issuer.discover(`https://${config.auth0.domain}`)
 
     const params = {
       redirect_uri: config.auth0.callbackURL,
+      sessionKey: config.auth0.sessionKey,
     };
 
     const strategy = new Strategy(

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -4,7 +4,11 @@
 
   <main id="content" role="main">
 
-    <div class="login-container" id="js-login-container" data-auth0-clientid="{{env.AUTH0_CLIENT_ID}}" data-auth0-domain="{{env.AUTH0_DOMAIN}}" data-auth0-callbackurl="{{env.AUTH0_CALLBACK_URL}}"><p>Init login...</p></div>
+    <div class="login-container" id="js-login-container"
+      data-auth0-clientid="{{ env.AUTH0_CLIENT_ID }}"
+      data-auth0-domain="{{ env.AUTH0_DOMAIN }}"
+      data-auth0-callbackurl="{{ env.AUTH0_CALLBACK_URL }}"
+      data-auth0-state="{{ state }}"><p>Init login...</p></div>
 
   </main>
 


### PR DESCRIPTION
## What

* Auth0 Lock v11 now depends on the `state` parameter being passed and checked during the authentication code flow.
* Generate and saving a state value to the session, using a defined session key, so that `node-openid-client` knows where to check it.
* Pass the generated state value to Lock

## How to review

1. Log in
2. See that you don't get a "state mismatch" error message