### PR TITLE
Request email from Auth0

### DIFF
--- a/app/assets/javascripts/modules/auth0-lock.js
+++ b/app/assets/javascripts/modules/auth0-lock.js
@@ -7,7 +7,7 @@ moj.Modules.auth0lock = {
         github: ['read:org', 'read:user', 'repo'],
       },
       params: {
-        scope: 'openid profile offline_access',
+        scope: 'openid email profile offline_access',
       },
       responseType: 'code',
     },

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -41,6 +41,7 @@ Issuer.discover(`https://${config.auth0.domain}`)
           refresh_token: tokenset.refresh_token,
           is_superuser: false,
           name: userinfo.name,
+          email: userinfo.email,
           username: userinfo.nickname,
         }));
       }


### PR DESCRIPTION
## What

* Now that we are fully OIDC protocol compliant, we need to explicitly request the email scope from Auth0 on authentication, and then retrieve the email claim from the userinfo response.

## How to review

1. Login as a new user
2. See you do not get an error like `IntegrityError: null value in column "email" violates not-null constraint`
3. Profit!