### PR TITLE
Refactor API clients for thread/process safety

### DIFF
--- a/app/api_clients/control_panel_api.js
+++ b/app/api_clients/control_panel_api.js
@@ -1,5 +1,4 @@
 const { APIClient, APIError } = require('./base');
-const config = require('../config');
 const log = require('bole')('control_panel_api');
 const passport = require('passport');
 

--- a/app/api_clients/control_panel_api.js
+++ b/app/api_clients/control_panel_api.js
@@ -36,11 +36,7 @@ class ControlPanelAPIClient extends APIClient {
   }
 }
 
-exports.APIClient = ControlPanelAPIClient;
-
-const api = new ControlPanelAPIClient(config.api);
-
-exports.api = api;
+exports.ControlPanelAPIClient = ControlPanelAPIClient;
 
 
 class DjangoError extends APIError {

--- a/app/api_clients/github.js
+++ b/app/api_clients/github.js
@@ -1,4 +1,3 @@
-const config = require('../config');
 const GithubAPI = require('github');
 const { ManagementClient } = require('auth0');
 

--- a/app/api_clients/github.js
+++ b/app/api_clients/github.js
@@ -36,7 +36,3 @@ class GithubAPIClient extends GithubAPI {
 }
 
 exports.GithubAPIClient = GithubAPIClient;
-
-const api = new GithubAPIClient(config);
-
-exports.api = api;

--- a/app/api_clients/kubernetes.js
+++ b/app/api_clients/kubernetes.js
@@ -1,4 +1,3 @@
-const config = require('../config');
 const { ControlPanelAPIClient } = require('./control_panel_api');
 const url = require('url');
 

--- a/app/api_clients/kubernetes.js
+++ b/app/api_clients/kubernetes.js
@@ -1,5 +1,5 @@
 const config = require('../config');
-const { APIClient } = require('./control_panel_api');
+const { ControlPanelAPIClient } = require('./control_panel_api');
 const url = require('url');
 
 
@@ -20,7 +20,7 @@ function get_namespace(username) {
 exports.get_namespace = get_namespace;
 
 
-class KubernetesAPIClient extends APIClient {
+class KubernetesAPIClient extends ControlPanelAPIClient {
   authenticate(user) {
     super.authenticate(user);
     this.user = user;
@@ -58,7 +58,3 @@ class KubernetesAPIClient extends APIClient {
 
 
 exports.KubernetesAPIClient = KubernetesAPIClient;
-
-const api = new KubernetesAPIClient(config.api);
-
-exports.api = api;

--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -1,12 +1,16 @@
 const { App, Bucket, User } = require('../models');
 const { Repo } = require('../models/github');
+const cls = require('continuation-local-storage');
 const config = require('../config');
-const github = require('../api_clients/github');
+const { GithubAPIClient } = require('../api_clients/github');
 const { url_for } = require('../routes');
 
 
 exports.new = (req, res, next) => {
-  github.api.authenticate(req.user)
+  const github_api = new GithubAPIClient(config);
+  const ns = cls.getNamespace(config.continuation_locals.namespace);
+  ns.set('github', github_api);
+  github_api.authenticate(req.user)
     .then(() => Promise.all([Repo.list(), Bucket.list()]))
     .then(([repos, buckets]) => {
       res.render('apps/new.html', {

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -1,7 +1,6 @@
-const { api } = require('../api_clients/control_panel_api');
-const kubernetes = require('../api_clients/kubernetes');
 const { Deployment, User } = require('../models');
 const config = require('../config');
+const cls = require('continuation-local-storage');
 const passport = require('passport');
 const raven = require('raven');
 const { url_for } = require('../routes');
@@ -10,14 +9,17 @@ const uuid = require('uuid');
 
 exports.home = (req, res, next) => {
   const { rstudio_is_deploying } = req.session;
+  const ns = cls.getNamespace(config.continuation_locals.namespace);
   req.session.rstudio_is_deploying = false;
 
   Promise.all([Deployment.list(), User.get(req.user.auth0_id)])
     .then(([tools, user]) => {
-      res.render('base/home.html', {
-        tools,
-        rstudio_is_deploying,
-        user,
+      ns.run(() => {
+        res.render('base/home.html', {
+          tools,
+          rstudio_is_deploying,
+          user,
+        });
       });
     })
     .catch(next);
@@ -25,8 +27,9 @@ exports.home = (req, res, next) => {
 
 
 exports.error_test = (req, res, next) => {
+  const ns = cls.getNamespace(config.continuation_locals.namespace);
   if (req.query.forbidden) {
-    api.authenticate({ id_token: 'invalid token' });
+    ns.get('cpanel').authenticate({ id_token: 'invalid token' });
   }
   return User.get('non-existent')
     .catch(next);
@@ -36,23 +39,8 @@ exports.error_test = (req, res, next) => {
 exports.auth_callback = [
   passport.authenticate('oidc'),
   (req, res, next) => {
-    raven.setContext({ user: req.user });
-
-    api.authenticate(req.user);
-    kubernetes.api.authenticate(req.user);
-
-    User.get(req.user.auth0_id)
-      .then((user) => {
-        req.user.data = Object.assign(req.user.data, user.data);
-
-        if (!user.email_verified) {
-          res.redirect(url_for('users.verify_email', { id: user.auth0_id }));
-        } else {
-          res.redirect(req.session.returnTo || '/');
-        }
-      })
-      .catch(next);
-  },
+    res.redirect(url_for('users.verify_email'));
+  }
 ];
 
 exports.login = (req, res, next) => {
@@ -69,9 +57,16 @@ exports.login = (req, res, next) => {
   }
 };
 
+
 exports.logout = (req, res) => {
   req.logout();
-  api.auth = null;
+  const ns = cls.getNamespace(config.continuation_locals.namespace);
+  ['cpanel', 'kubernetes'].forEach((api) => {
+    const client = ns.get(api);
+    if (client) {
+      client.auth = null;
+    }
+  });
   req.session.destroy(() => {
     res.clearCookie(config.session.name);
     res.redirect('/');

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -2,7 +2,6 @@ const { Deployment, User } = require('../models');
 const config = require('../config');
 const cls = require('continuation-local-storage');
 const passport = require('passport');
-const raven = require('raven');
 const { url_for } = require('../routes');
 const uuid = require('uuid');
 
@@ -38,9 +37,9 @@ exports.error_test = (req, res, next) => {
 
 exports.auth_callback = [
   passport.authenticate('oidc'),
-  (req, res, next) => {
+  (req, res) => {
     res.redirect(url_for('users.verify_email'));
-  }
+  },
 ];
 
 exports.login = (req, res, next) => {

--- a/app/config.js
+++ b/app/config.js
@@ -47,6 +47,10 @@ config.cluster = {
   tools_domain: process.env.TOOLS_DOMAIN,
 };
 
+config.continuation_locals = {
+  namespace: 'cpfrontend',
+};
+
 config.ensure_login = {
   exclude: [
     /^\/callback/,
@@ -74,11 +78,12 @@ config.js = {
 config.log = {
   requests: process.env.ENABLE_ACCESS_LOGS !== 'false',
   stream: process.stdout,
-  level: process.env.LOG_LEVEL || 'debug',
+  level: 'debug',
 };
 
 // order is important!
 config.middleware = [
+  'continuation-locals',
   'raven-request-handler',
   'request-logging',
   'static',

--- a/app/config.js
+++ b/app/config.js
@@ -78,7 +78,7 @@ config.js = {
 config.log = {
   requests: process.env.ENABLE_ACCESS_LOGS !== 'false',
   stream: process.stdout,
-  level: 'debug',
+  level: process.env.LOG_LEVEL || 'debug',
 };
 
 // order is important!

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -1,13 +1,21 @@
-const cpanel = require('../api_clients/control_panel_api');
-const kubernetes = require('../api_clients/kubernetes');
+const { ControlPanelAPIClient } = require('../api_clients/control_panel_api');
+const { KubernetesAPIClient } = require('../api_clients/kubernetes');
+const cls = require('continuation-local-storage');
 
 
 module.exports = (app, conf, log) => {
   log.info('adding api');
   return (req, res, next) => {
+    const ns = cls.getNamespace(conf.continuation_locals.namespace);
+
     if (req.user && req.user.id_token) {
-      cpanel.api.authenticate(req.user);
-      kubernetes.api.authenticate(req.user);
+      const cpanel = new ControlPanelAPIClient(conf.api);
+      cpanel.authenticate(req.user);
+      ns.set('cpanel', cpanel);
+
+      const kubernetes = new KubernetesAPIClient(conf.api);
+      kubernetes.authenticate(req.user);
+      ns.set('kubernetes', kubernetes);
     }
     next();
   };

--- a/app/middleware/continuation-locals.js
+++ b/app/middleware/continuation-locals.js
@@ -1,0 +1,18 @@
+const cls = require('continuation-local-storage');
+
+
+module.exports = (app, conf, log) => {
+  log.info('adding continuation local storage');
+
+  const ns = cls.createNamespace(conf.continuation_locals.namespace);
+
+  return (req, res, next) => {
+    ns.bindEmitter(req);
+    ns.bindEmitter(res);
+
+    ns.run(() => {
+      ns.set('test', 'foo');
+      next();
+    });
+  };
+};

--- a/app/middleware/continuation-locals.js
+++ b/app/middleware/continuation-locals.js
@@ -11,7 +11,6 @@ module.exports = (app, conf, log) => {
     ns.bindEmitter(res);
 
     ns.run(() => {
-      ns.set('test', 'foo');
       next();
     });
   };

--- a/app/models/github.js
+++ b/app/models/github.js
@@ -1,11 +1,20 @@
+const cls = require('continuation-local-storage');
 const config = require('../config');
 const { Model, ModelSet } = require('./base');
-const github = require('../api_clients/github');
 
 
 class Repo extends Model {
+  static get github() {
+    const ns = cls.getNamespace(config.continuation_locals.namespace);
+    return ns.get('github');
+  }
+
+  get github() {
+    return this.constructor.github;
+  }
+
   static list(params = {}) {
-    return Promise.all(config.github.orgs.map(org => github.api.repos.getForOrg({
+    return Promise.all(config.github.orgs.map(org => this.github.repos.getForOrg({
       org,
       type: 'all',
       page: params.page || 1,

--- a/app/users/handlers.js
+++ b/app/users/handlers.js
@@ -39,8 +39,10 @@ exports.user_edit = (req, res, next) => {
 
 
 exports.verify_email = (req, res, next) => {
-  User.get(req.params.id)
+  User.get(req.user.auth0_id)
     .then((user) => {
+      req.user.data = Object.assign(req.user.data, user.data);
+
       if (req.method === 'POST') {
         user.email = req.body.email;
         user.email_verified = true;
@@ -51,6 +53,10 @@ exports.verify_email = (req, res, next) => {
             res.redirect(req.session.returnTo || '/');
           })
           .catch(next);
+      }
+
+      if (user.email_verified) {
+        return res.redirect(req.session.returnTo || '/');
       }
 
       return res.render('users/verify_email.html', { user });

--- a/app/users/routes.js
+++ b/app/users/routes.js
@@ -6,6 +6,6 @@ module.exports = [
   { name: 'list', pattern: '/users', handler: handlers.list_users },
   { name: 'details', pattern: '/users/:id', handler: handlers.user_details },
   { name: 'edit', pattern: '/users/:id/edit', handler: handlers.user_edit },
-  { name: 'verify_email', pattern: '/users/:id/verify-email', handler: handlers.verify_email },
-  { name: 'verify_email', method: 'POST', pattern: '/users/:id/verify-email', handler: handlers.verify_email },
+  { name: 'verify_email', pattern: '/verify-email', handler: handlers.verify_email },
+  { name: 'verify_email', method: 'POST', pattern: '/verify-email', handler: handlers.verify_email },
 ];

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "concat-files": "^0.1.1",
     "connect-ensure-login": "^0.1.1",
     "connect-redis": "^3.3.2",
+    "continuation-local-storage": "^3.2.1",
     "cookie-parser": "^1.4.3",
     "dotenv": "^4.0.0",
     "express": "4.15.4",

--- a/test/api_clients/control_panel_api.js
+++ b/test/api_clients/control_panel_api.js
@@ -2,12 +2,12 @@
 const { assert } = require('chai');
 const { config, mock_api } = require('../conftest');
 
-const { APIClient } = require('../../app/api_clients/control_panel_api');
+const { ControlPanelAPIClient } = require('../../app/api_clients/control_panel_api');
 const { App, ModelSet } = require('../../app/models');
 
 
 describe('Control Panel API Client', () => {
-  const client = new APIClient(config.api);
+  const client = new ControlPanelAPIClient(config.api);
 
   it('rejects an invalid auth token', () => {
     const reason = {

--- a/test/conftest.js
+++ b/test/conftest.js
@@ -1,8 +1,32 @@
 "use strict";
+const cls = require('continuation-local-storage');
 const config = require('../app/config');
+const { ControlPanelAPIClient } = require('../app/api_clients/control_panel_api');
+const { GithubAPIClient } = require('../app/api_clients/github');
+const { KubernetesAPIClient } = require('../app/api_clients/kubernetes');
 const nock = require('nock');
 const { load_routes, url_for } = require('../app/routes');
+const { User } = require('../app/models');
 
+
+const ns = cls.createNamespace(config.continuation_locals.namespace);
+exports.ns = ns;
+
+const user = new User({ id_token: 'dummy-token', username: 'test' });
+exports.user = user;
+
+exports.withAPI = (fn) => {
+  return () => {
+    return ns.run(() => {
+      ns.set('cpanel', new ControlPanelAPIClient(config.api));
+      ns.set('github', new GithubAPIClient(config));
+      const kubernetes = new KubernetesAPIClient(config.api);
+      kubernetes.authenticate(user);
+      ns.set('kubernetes', kubernetes)
+      return fn();
+    });
+  };
+};
 
 load_routes();
 

--- a/test/models/control_panel_api.js
+++ b/test/models/control_panel_api.js
@@ -1,11 +1,12 @@
 "use strict";
 const { assert } = require('chai');
-const { mock_api } = require('../conftest');
+const { config, mock_api, ns, withAPI } = require('../conftest');
+const { ControlPanelAPIClient } = require('../../app/api_clients/control_panel_api');
 const { App, DoesNotExist } = require('../../app/models');
 const apps_response = require('../fixtures/apps');
 
 
-describe('Control Panel API Model', () => {
+describe('Control Panel API Model', function () {
   it('has a primary key', () => {
     assert.equal(App.pk, 'id');
   });
@@ -14,7 +15,7 @@ describe('Control Panel API Model', () => {
     assert.equal(App.endpoint, 'apps');
   });
 
-  it('lists all instances', () => {
+  it('lists all instances', withAPI(() => {
     mock_api()
       .get('/apps/')
       .reply(200, apps_response);
@@ -24,10 +25,10 @@ describe('Control Panel API Model', () => {
         assert.equal(apps.length, apps_response.results.length);
         assert.instanceOf(apps[0], App);
         assert.instanceOf(apps[1], App);
-      });
-  });
+    });
+  }));
 
-  it('can Create an instance', () => {
+  it('can Create an instance', withAPI(() => {
     const app_data = {
       name: 'test-app',
     };
@@ -43,10 +44,10 @@ describe('Control Panel API Model', () => {
       .then((new_app) => {
         assert.exists(new_app[App.pk]);
         assert.equal(new_app.name, expected.name);
-      });
-  });
+    });
+  }));
 
-  it('Retrieves an instance by primary key', () => {
+  it('Retrieves an instance by primary key', withAPI(() => {
     mock_api()
       .get('/apps/1/')
       .reply(200, apps_response.results[0]);
@@ -55,9 +56,9 @@ describe('Control Panel API Model', () => {
       .then((app) => {
         assert.equal(app[App.pk], 1);
       });
-  });
+  }));
 
-  it('throws an exception if no instance found', () => {
+  it('throws an exception if no instance found', withAPI(() => {
     mock_api()
       .get('/apps/0/')
       .reply(404, 'Not Found');
@@ -69,18 +70,18 @@ describe('Control Panel API Model', () => {
       .catch((error) => {
         assert.instanceOf(error, DoesNotExist);
       });
-  });
+  }));
 
-  it('Deletes an instance by primary key', () => {
+  it('Deletes an instance by primary key', withAPI(() => {
     mock_api()
       .delete('/apps/1/')
       .reply(204);
 
     return App.delete(1);
-  });
+  }));
 
   describe('instance', () => {
-    it('can be Created', () => {
+    it('can be Created', withAPI(() => {
       const app_data = {
         name: 'test-app',
       };
@@ -97,9 +98,9 @@ describe('Control Panel API Model', () => {
           assert.exists(new_app[App.pk]);
           assert.equal(new_app.name, expected.name);
         });
-    });
+    }));
 
-    it('can be Updated', () => {
+    it('can be Updated', withAPI(() => {
       const app_data = {
         name: 'test-app',
       };
@@ -120,9 +121,9 @@ describe('Control Panel API Model', () => {
         .then((updated_app) => {
           assert.equal(updated_app.name, app_data.name);
         });
-    });
+    }));
 
-    it('can be Deleted', () => {
+    it('can be Deleted', withAPI(() => {
       const existing_app = new App({ id: 1 });
 
       mock_api()
@@ -130,6 +131,6 @@ describe('Control Panel API Model', () => {
         .reply(204);
 
       return existing_app.delete();
-    });
+    }));
   });
 });

--- a/test/models/github.js
+++ b/test/models/github.js
@@ -1,12 +1,12 @@
 const { assert } = require('chai');
-const { config } = require('../conftest');
+const { config, withAPI } = require('../conftest');
 const nock = require('nock');
 const { ModelSet, Repo } = require('../../app/models');
 
 
 describe('Github model', () => {
   describe('Repo', () => {
-    it('list method returns a ModelSet of Repo objects', () => {
+    it('list method returns a ModelSet of Repo objects', withAPI(() => {
       const repos_response = require('../fixtures/repos');
 
       config.github.orgs = [
@@ -29,6 +29,6 @@ describe('Github model', () => {
         .then((repos) => {
           assert.deepEqual(repos, expected);
         });
-    });
+    }));
   });
 });

--- a/test/models/kubernetes.js
+++ b/test/models/kubernetes.js
@@ -1,20 +1,18 @@
 "use strict";
 const { assert } = require('chai');
-const { mock_api } = require('../conftest');
-const kubernetes = require('../../app/api_clients/kubernetes');
+const { config, mock_api, ns, user, withAPI } = require('../conftest');
+const { KubernetesAPIClient } = require('../../app/api_clients/kubernetes');
 const { Deployment, DoesNotExist, ModelSet, Pod, User } = require('../../app/models');
 const deployments_response = require('../fixtures/deployments');
 const pods_response = require('../fixtures/deployment-pods');
 
 
 describe('Kubernetes Model', () => {
-  const user = new User({ id_token: 'dummy-token', username: 'test' });
-  const ns = user.kubernetes_namespace;
-  kubernetes.api.authenticate(user);
+  const k8s_ns = user.kubernetes_namespace;
 
-  it('lists all instances', () => {
+  it('lists all instances', withAPI(() => {
     mock_api()
-      .get(`/k8s/api/v1/namespaces/${ns}/pods`)
+      .get(`/k8s/api/v1/namespaces/${k8s_ns}/pods`)
       .reply(200, pods_response);
 
     return Pod.list()
@@ -22,24 +20,24 @@ describe('Kubernetes Model', () => {
         assert.equal(pods.length, pods_response.items.length);
         assert.instanceOf(pods[0], Pod);
       });
-  });
+  }));
 
-  it('Retrieves an instance by name', () => {
+  it('Retrieves an instance by name', withAPI(() => {
     const name = 'andyhd-rstudio-rstudio-4159917267-vlb52';
 
     mock_api()
-      .get(`/k8s/api/v1/namespaces/${ns}/pods/${name}`)
+      .get(`/k8s/api/v1/namespaces/${k8s_ns}/pods/${name}`)
       .reply(200, pods_response.items[0]);
 
     return Pod.get(name)
       .then((pod) => {
         assert.equal(pod.metadata.name, name);
       });
-  });
+  }));
 
-  it('throws an exception if no instance found', () => {
+  it('throws an exception if no instance found', withAPI(() => {
     mock_api()
-      .get(`/k8s/api/v1/namespaces/${ns}/pods/non-existent`)
+      .get(`/k8s/api/v1/namespaces/${k8s_ns}/pods/non-existent`)
       .reply(404, 'Not Found');
 
     return Pod.get('non-existent')
@@ -49,26 +47,26 @@ describe('Kubernetes Model', () => {
       .catch((error) => {
         assert.instanceOf(error, DoesNotExist);
       });
-  });
+  }));
 
-  it('Deletes all instances', () => {
+  it('Deletes all instances', withAPI(() => {
     const delete_request = mock_api()
-      .delete(`/k8s/api/v1/namespaces/${ns}/pods`)
+      .delete(`/k8s/api/v1/namespaces/${k8s_ns}/pods`)
       .reply(200, {});
 
     return Pod.delete_all()
       .then(() => {
         assert(delete_request.isDone());
       });
-  });
+  }));
 
   describe('Deployment', () => {
-    it('has a number of pods', () => {
+    it('has a number of pods', withAPI(() => {
       const expected = new ModelSet(Pod, pods_response.items);
       const rstudio = new Deployment(deployments_response.items[0]);
 
       const pods_request = mock_api()
-        .get(`/k8s/api/v1/namespaces/${ns}/pods?labelSelector=app%3Drstudio`)
+        .get(`/k8s/api/v1/namespaces/${k8s_ns}/pods?labelSelector=app%3Drstudio`)
         .reply(200, pods_response);
 
       rstudio.get_pods()
@@ -76,13 +74,13 @@ describe('Kubernetes Model', () => {
           assert(pods_request.isDone());
           assert.deepEqual(pods, expected);
         });
-    });
+    }));
 
-    it('restarts by deleting all pods', () => {
+    it('restarts by deleting all pods', withAPI(() => {
       const rstudio = new Deployment(deployments_response.items[0]);
 
       const delete_pods = mock_api()
-        .delete(`/k8s/api/v1/namespaces/${ns}/pods?labelSelector=app%3Drstudio`)
+        .delete(`/k8s/api/v1/namespaces/${k8s_ns}/pods?labelSelector=app%3Drstudio`)
         .reply(200, {
           'apiVersion': 'v1',
           'kind': 'Status',
@@ -93,15 +91,15 @@ describe('Kubernetes Model', () => {
         .then(() => {
           assert(delete_pods.isDone());
         });
-    });
+    }));
 
-    it('lists tools with associated pods', () => {
+    it('lists tools with associated pods', withAPI(() => {
       const get_deployments = mock_api()
-        .get(`/k8s/apis/apps/v1beta2/namespaces/${ns}/deployments`)
+        .get(`/k8s/apis/apps/v1beta2/namespaces/${k8s_ns}/deployments`)
         .reply(200, deployments_response);
 
       const get_pods = mock_api()
-        .get(`/k8s/api/v1/namespaces/${ns}/pods`)
+        .get(`/k8s/api/v1/namespaces/${k8s_ns}/pods`)
         .reply(200, pods_response);
 
       Deployment.list()
@@ -111,6 +109,6 @@ describe('Kubernetes Model', () => {
           assert.equal(tools.length, deployments_response.items.length);
           assert.isAtLeast(tools[0].pods.length, 1);
         });
-    });
+    }));
   });
 });

--- a/test/test-app-delete.js
+++ b/test/test-app-delete.js
@@ -1,15 +1,11 @@
 const { assert } = require('chai');
-
-const { config, mock_api, url_for } = require('./conftest');
+const { config, mock_api, ns, url_for, withAPI } = require('./conftest');
 const handlers = require('../app/apps/handlers');
 
 
 describe('Delete app', () => {
-
   describe('when deleting an app', () => {
-
-    it('makes a DELETE request to the API', () => {
-
+    it('makes a DELETE request to the API', withAPI(() => {
       const app_id = 2;
       const redirect_to = '/';
       const user = require('./fixtures/user');
@@ -38,6 +34,6 @@ describe('Delete app', () => {
           assert(delete_app.isDone(), `Didn't make DELETE request to API endpoint to /apps/${app_id}/`);
           assert.equal(redirect_url, redirect_to);
         });
-    });
+    }));
   });
 });

--- a/test/test-app-edit.js
+++ b/test/test-app-edit.js
@@ -1,15 +1,12 @@
 const { App, Bucket, ModelSet, User } = require('../app/models');
 const { assert } = require('chai');
-
-const { config, mock_api, url_for } = require('./conftest');
+const { config, mock_api, url_for, withAPI } = require('./conftest');
 const handlers = require('../app/apps/handlers');
 
 
 describe('Edit app form', () => {
-
   describe('when rendered', () => {
-
-    it('loads app, buckets and users from API', () => {
+    it('loads app, buckets and users from API', withAPI(() => {
       const app = require('./fixtures/app');
       const buckets = require('./fixtures/buckets');
       const user = require('./fixtures/user');
@@ -55,8 +52,6 @@ describe('Edit app form', () => {
           assert.deepEqual(args.context.buckets_options, expected.buckets);
           assert.deepEqual(args.context.users, expected.users);
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-apps3buckets-create.js
+++ b/test/test-apps3buckets-create.js
@@ -1,15 +1,12 @@
 const { assert } = require('chai');
 
-const { config, mock_api, url_for } = require('./conftest');
+const { config, mock_api, url_for, withAPI } = require('./conftest');
 const handlers = require('../app/apps3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
-
   describe('when granting access to user', () => {
-
-    it('make request to API', () => {
-
+    it('make request to API', withAPI(() => {
       const bucket_id = 42;
       const app_id = 1;
 
@@ -46,6 +43,6 @@ describe('Edit bucket form', () => {
           const expected_redirect_url = url_for('apps.details', { id: app_id });
           assert.equal(redirect_url, expected_redirect_url);
         });
-    });
+    }));
   });
 });

--- a/test/test-apps3buckets-delete.js
+++ b/test/test-apps3buckets-delete.js
@@ -1,15 +1,11 @@
 const { assert } = require('chai');
-
-const { config, mock_api } = require('./conftest');
+const { config, mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/apps3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
-
   describe('when revoking access to user', () => {
-
-    it('make request to API', () => {
-
+    it('make request to API', withAPI(() => {
       const apps3bucket_id = 42;
       const redirect_to = 'apps/123';
 
@@ -36,6 +32,6 @@ describe('Edit bucket form', () => {
           assert(delete_apps3buckets.isDone(), `Did't make DELETE request to API endpoint to /apps3buckets/${apps3bucket_id}/`);
           assert.equal(redirect_url, redirect_to);
         });
-    });
+    }));
   });
 });

--- a/test/test-apps3buckets-update.js
+++ b/test/test-apps3buckets-update.js
@@ -1,15 +1,11 @@
 const { assert } = require('chai');
-
-const { config, mock_api } = require('./conftest');
+const { config, mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/apps3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
-
   describe('when updating user access', () => {
-
-    it('make request to API', () => {
-
+    it('make request to API', withAPI(() => {
       const apps3bucket_id = 42;
       const access_level = 'readonly';
       const redirect_to = 'apps/123';
@@ -41,6 +37,6 @@ describe('Edit bucket form', () => {
 
           assert.equal(redirect_url, redirect_to);
         });
-    });
+    }));
   });
 });

--- a/test/test-bucket-details.js
+++ b/test/test-bucket-details.js
@@ -2,16 +2,13 @@
 
 const { assert } = require('chai');
 const { App, Bucket, ModelSet, User } = require('../app/models');
-const { config, mock_api } = require('./conftest');
+const { config, mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/buckets/handlers');
 
 
 describe('Edit bucket form', () => {
-
   describe('when rendered', () => {
-
-    it('loads bucket, apps and users from API', () => {
-
+    it('loads bucket, apps and users from API', withAPI(() => {
       const bucket = require('./fixtures/bucket');
       const apps = require('./fixtures/apps');
       const users = require('./fixtures/users');
@@ -59,8 +56,6 @@ describe('Edit bucket form', () => {
           assert.deepEqual(args.context.apps_options, expected.apps);
           assert.deepEqual(args.context.users_options, expected.users);
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-buckets-views.js
+++ b/test/test-buckets-views.js
@@ -1,15 +1,12 @@
 "use strict";
 const { assert } = require('chai');
-
-const { config, mock_api, url_for } = require('./conftest');
+const { config, mock_api, url_for, withAPI } = require('./conftest');
 const handlers = require('../app/buckets/handlers');
 
 
 describe('buckets view', () => {
-
   describe('add bucket', () => {
-
-    it('creates a new bucket and redirects', () => {
+    it('creates a new bucket and redirects', withAPI(() => {
       const bucket_data = {
         'new-datasource-name': 'dev-test-bucket'
       };
@@ -46,8 +43,6 @@ describe('buckets view', () => {
         .then((redirect_url) => {
           assert.equal(redirect_url, url_for('buckets.details', { id: created_bucket.id }));
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-login.js
+++ b/test/test-login.js
@@ -33,15 +33,9 @@ describe('Logging in', () => {
         handlers.auth_callback[1](req, res, reject);
       });
 
-      //const user_details_request = mock_api()
-        //.get(`/users/${escape(user.auth0_id)}/`)
-        //.matchHeader('Authorization', `JWT ${id_token}`)
-        //.reply(200, user);
-
       return request
         .then((redirect_url) => {
           assert.equal(redirect_url, returnTo);
-          //assert(user_details_request.isDone(), 'API call expected');
         });
     }));
   });

--- a/test/test-login.js
+++ b/test/test-login.js
@@ -1,18 +1,16 @@
 "use strict";
 const { assert } = require('chai');
-const { mock_api, url_for } = require('./conftest');
+const { mock_api, url_for, withAPI } = require('./conftest');
 const { User } = require('../app/models');
 const handlers = require('../app/base/handlers');
 
 
 describe('Logging in', () => {
-
   describe('an authenticated user', () => {
-
-    it('fetches the API user details', () => {
+    it('fetches the API user details', withAPI(() => {
       const auth0_id = 'github|12345';
       const id_token = 'test-token'
-      const returnTo = url_for('users.verify_email', { id: auth0_id });
+      const returnTo = url_for('users.verify_email');
       const username = 'test';
 
       const user = {
@@ -35,18 +33,16 @@ describe('Logging in', () => {
         handlers.auth_callback[1](req, res, reject);
       });
 
-      const user_details_request = mock_api()
-        .get(`/users/${escape(user.auth0_id)}/`)
-        .matchHeader('Authorization', `JWT ${id_token}`)
-        .reply(200, user);
+      //const user_details_request = mock_api()
+        //.get(`/users/${escape(user.auth0_id)}/`)
+        //.matchHeader('Authorization', `JWT ${id_token}`)
+        //.reply(200, user);
 
       return request
         .then((redirect_url) => {
           assert.equal(redirect_url, returnTo);
-          assert(user_details_request.isDone(), 'API call expected');
+          //assert(user_details_request.isDone(), 'API call expected');
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-user-edit.js
+++ b/test/test-user-edit.js
@@ -2,15 +2,13 @@
 
 const { assert } = require('chai');
 const { App, Bucket, ModelSet, User } = require('../app/models');
-const { config, mock_api } = require('./conftest');
+const { config, mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/users/handlers');
 
 
 describe('Edit user form', () => {
-
   describe('when rendered', () => {
-
-    it('loads user, apps and buckets from API', () => {
+    it('loads user, apps and buckets from API', withAPI(() => {
       const user = require('./fixtures/user');
       const apps = require('./fixtures/apps');
       const buckets = require('./fixtures/buckets');
@@ -48,8 +46,6 @@ describe('Edit user form', () => {
           assert.deepEqual(args.context.apps_options, expected.apps);
           assert.deepEqual(args.context.buckets_options, expected.buckets);
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-users3buckets-create.js
+++ b/test/test-users3buckets-create.js
@@ -1,15 +1,13 @@
 "use strict";
 
 const { assert } = require('chai');
-const { config, mock_api, url_for } = require('./conftest');
+const { config, mock_api, url_for, withAPI } = require('./conftest');
 const handlers = require('../app/users3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
-
   describe('when granting access to user', () => {
-
-    it('make request to API', () => {
+    it('make request to API', withAPI(() => {
       const bucket_id = 42;
       const user_id = 'github|123';
 
@@ -45,8 +43,6 @@ describe('Edit bucket form', () => {
           const expected_redirect_url = url_for('buckets.details', { id: bucket_id });
           assert.equal(redirect_url, expected_redirect_url);
         });
-    });
-
+    }));
   });
-
 });

--- a/test/test-users3buckets-delete.js
+++ b/test/test-users3buckets-delete.js
@@ -1,17 +1,15 @@
 const { assert } = require('chai');
-const nock = require('nock');
-
-const config = require('../app/config');
+const { config, mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/users3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
   describe('when revoking access to user', () => {
-    it('make request to API', () => {
+    it('make request to API', withAPI(() => {
       const users3bucket_id = 42;
       const redirect_to = 'users/github|123';
 
-      const delete_users3buckets = nock(config.api.base_url)
+      const delete_users3buckets = mock_api()
         .delete(`/users3buckets/${users3bucket_id}/`)
         .reply(204);
 
@@ -34,6 +32,6 @@ describe('Edit bucket form', () => {
           assert(delete_users3buckets.isDone(), `Did't make DELETE request to API endpoint to /users3buckets/${users3bucket_id}/`);
           assert.equal(redirect_url, redirect_to);
         });
-    });
+    }));
   });
 });

--- a/test/test-users3buckets-update.js
+++ b/test/test-users3buckets-update.js
@@ -1,18 +1,16 @@
 const { assert } = require('chai');
-const nock = require('nock');
-
-const config = require('../app/config');
+const { mock_api, withAPI } = require('./conftest');
 const handlers = require('../app/users3buckets/handlers');
 
 
 describe('Edit bucket form', () => {
   describe('when updating user access', () => {
-    it('make request to API', () => {
+    it('make request to API', withAPI(() => {
       const users3bucket_id = 42;
       const access_level = 'readonly';
       const redirect_to = 'buckets/123';
 
-      const patch_users3buckets = nock(config.api.base_url)
+      const patch_users3buckets = mock_api()
         .patch(`/users3buckets/${users3bucket_id}/`, {
           id: users3bucket_id,
           access_level: access_level,
@@ -39,6 +37,6 @@ describe('Edit bucket form', () => {
 
           assert.equal(redirect_url, redirect_to);
         });
-    });
+    }));
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,13 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async-listener@^0.6.0:
+  version "0.6.9"
+  resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.9.tgz#51bc95e41095417f33922fb4dee4f232b3226488"
+  dependencies:
+    semver "^5.3.0"
+    shimmer "^1.1.0"
+
 async@~0.2.6:
   version "0.2.10"
   resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
@@ -1072,6 +1079,13 @@ content-type@~1.0.2, content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
+continuation-local-storage@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz#11f613f74e914fe9b34c92ad2d28fe6ae1db7ffb"
+  dependencies:
+    async-listener "^0.6.0"
+    emitter-listener "^1.1.1"
+
 convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
@@ -1327,6 +1341,12 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+emitter-listener@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.1.tgz#e8bbbe8244bc8e0d0b4ef71cd14294c7f241c7ec"
+  dependencies:
+    shimmer "^1.2.0"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -4027,6 +4047,10 @@ shebang-command@^1.2.0:
 shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+shimmer@^1.1.0, shimmer@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.2.0.tgz#f966f7555789763e74d8841193685a5e78736665"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
## What

There was a bug where a user restarted their RStudio instance and got a flash message telling them that another user's instance was being restarted.

The problem may have been caused by a fundamental mistake in that the API client instances were singletons and their authentication state may be shared between requests.

It may have been possible that an API client instance was authenticated with User A's credentials, then in the next request from User B, that same API client instance was used to access the API - still using User A's credentials.

This refactor removes the singleton instances and instead instantiates API clients on every request, and stores them in a namespace object in scope only for a specific request - this is enabled by the `continuation-local-storage` module. This should remove the possibility that an API client instance might be shared between requests.