### PR TITLE
Display error message when creating app with used repo URL

### DIFF
--- a/app/assets/javascripts/modules/repo-description.js
+++ b/app/assets/javascripts/modules/repo-description.js
@@ -47,6 +47,7 @@ moj.Modules.repoDescription = {
           this.repoSelected = true;
         },
         onCancel: () => {
+          this.$repoSlugTypeahead.val('');
           this.resetTypeahead();
         },
         onSubmit: () => this.repoSelected,
@@ -57,7 +58,6 @@ moj.Modules.repoDescription = {
   resetTypeahead() {
     this.repoSelected = false;
     this.$repoSlugSelect.hide();
-    this.$repoSlugTypeahead.val('');
     this.updateDescription('');
     $('.typeahead__result, .typeahead__cancel-button').remove();
     $('.typeahead__container').removeClass('cancel');

--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -10,12 +10,12 @@
 
 
 <form action="{{ url_for('apps.create') }}" method="post">
-  <div class="form-group {% if errors.name %} form-group-error {% endif %}">
+  <div class="form-group {% if errors.repo_url %} form-group-error {% endif %}">
     <label for="name" class="heading-medium form-label">
       Github repository URL
     </label>
-    {% if errors.name %}
-      {% for error in errors.name %}
+    {% if errors.repo_url %}
+      {% for error in errors.repo_url %}
         <span class="error-message">{{ error }}</span>
       {% endfor %}
     {% endif %}
@@ -32,7 +32,7 @@
     <div class="typeahead__container">
       <div class="typeahead__field">
         <span class="typeahead__query">
-          <input id="repo_typeahead" class="form-control form-control-1-2" name="repo_typeahead" type="search" autocomplete="off" placeholder="Start typing to search...">
+          <input id="repo_typeahead" class="form-control form-control-1-2" name="repo_typeahead" type="search" autocomplete="off" placeholder="Start typing to search..." value="{{ req.body.repo_typeahead }}">
         </span>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./app/server.js",
   "scripts": {
     "start": "$([ \"x$NODE_RESTART\" == \"x0\" ] && echo node || echo nodemon ) ./app/server.js | bistre",
-    "test": "mocha -C -R list --recursive --use_strict",
+    "test": "mocha -C -R list --recursive",
     "collect-static": "node ./bin/collect-static.js | bistre",
     "lint": "node node_modules/eslint/bin/eslint.js app || exit 0"
   },

--- a/test/apps/test-create.js
+++ b/test/apps/test-create.js
@@ -1,5 +1,6 @@
 const { assert } = require('chai');
-const { dispatch, mock_api, url_for } = require('../conftest');
+const { config, dispatch, mock_api, url_for, user } = require('../conftest');
+const nock = require('nock');
 const handlers = require('../../app/apps/handlers');
 
 
@@ -7,11 +8,9 @@ describe('apps/create', () => {
   it('creates a new app and redirects to the new app details', () => {
     const form_data = {
       repo_typeahead: 'test-app',
-      description: 'test app description',
       repo_url: 'http://example.com',
     };
     const created_app = { id: 1 };
-    const user = { auth0_id: 'test-user', id_token: 'dummy-token' };
 
     mock_api()
       .post('/apps/')
@@ -26,9 +25,47 @@ describe('apps/create', () => {
         is_admin: true,
       });
 
-    return dispatch(handlers.create, { body: form_data, user })
+    return dispatch(handlers.create, { body: form_data })
       .then(({ redirect_url }) => {
         assert.equal(redirect_url, url_for('apps.details', { id: created_app.id }));
+      });
+  });
+
+  it('shows an error if an app exists for the specified repo', () => {
+    const form_data = {
+      repo_typeahead: 'test-app',
+      repo_url: 'http://example.com',
+    };
+
+    const errors = {
+      repo_url: 'app with this repo url already exists',
+    };
+
+    user.github_access_token = 'test-github-token';
+
+    mock_api()
+      .post('/apps/')
+      .reply(400, errors);
+
+    config.github.orgs = [
+      'test-org-1',
+      'test-org-2',
+    ];
+    config.github.orgs.forEach((org) => {
+      nock(`https://${config.github.host}`)
+        .get(`/orgs/${org}/repos?type=all&page=1&per_page=500`)
+        .reply(200, []);
+    });
+
+    mock_api()
+      .get('/s3buckets/')
+      .reply(200, []);
+
+    return dispatch(handlers.create, { body: form_data })
+      .then(({ redirect_url, template, context }) => {
+        assert.isUndefined(redirect_url);
+        assert.equal(template, 'apps/new.html');
+        assert.deepEqual(context.errors, errors);
       });
   });
 });


### PR DESCRIPTION
## What

* Refactored `app.create` for readability
* Pass required Github repos list and S3buckets list to create app form on error - this was the cause of the error message: the template expects to have repos and buckets for the form inputs, but the form was being rendered with only the error object.
* Add regression test for this issue
* Pre-populate form with entered repo name

## How to review

1. Login and create an app 
2. Now try to create another app with the same repo URL
3. See a form error message highlighting the URL input

See https://github.com/ministryofjustice/analytics-platform/issues/20