### PR TITLE
fix logout with returnTo URL

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -67,7 +67,8 @@ exports.logout = (req, res) => {
     }
   });
   req.session.destroy(() => {
+    const encodedReturnTo = encodeURI(`${config.app.protocol}://${config.app.host}:${config.app.port}`);
     res.clearCookie(config.session.name);
-    res.redirect('/');
+    res.redirect(`https://${config.auth0.domain}/v2/logout?returnTo=${encodedReturnTo}&client_id=${config.auth0.clientID}`);
   });
 };

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -6,6 +6,11 @@ const { url_for } = require('../routes');
 const uuid = require('uuid');
 
 
+function sso_logout_url() {
+  const returnTo = encodeURI(`${config.app.protocol}://${config.app.host}:${config.app.port}`);
+  return `https://${config.auth0.domain}${config.auth0.sso_logout_url}?returnTo=${returnTo}&client_id=${config.auth0.clientID}`;
+}
+
 exports.home = (req, res, next) => {
   const { rstudio_is_deploying } = req.session;
   const ns = cls.getNamespace(config.continuation_locals.namespace);
@@ -67,8 +72,7 @@ exports.logout = (req, res) => {
     }
   });
   req.session.destroy(() => {
-    const encodedReturnTo = encodeURI(`${config.app.protocol}://${config.app.host}:${config.app.port}`);
     res.clearCookie(config.session.name);
-    res.redirect(`https://${config.auth0.domain}/v2/logout?returnTo=${encodedReturnTo}&client_id=${config.auth0.clientID}`);
+    res.redirect(sso_logout_url());
   });
 };

--- a/app/config.js
+++ b/app/config.js
@@ -15,7 +15,7 @@ config.app = {
   asset_path: '/static/',
   protocol: process.env.APP_PROTOCOL || 'http',
   host: process.env.APP_HOST || 'localhost',
-  port: process.env.APP_PORT || '3000',
+  port: process.env.APP_PORT || process.env.EXPRESS_PORT || 3000,
 };
 
 config.apps = [
@@ -40,6 +40,7 @@ config.auth0 = {
   retries: 2,
   sessionKey: `oidc:${process.env.AUTH0_DOMAIN}`,
   scope: 'openid email profile offline_access',
+  sso_logout_url: '/v2/logout',
 };
 
 config.babel = {

--- a/app/config.js
+++ b/app/config.js
@@ -13,6 +13,9 @@ config.api = {
 config.app = {
   env: process.env.ENV || 'dev',
   asset_path: '/static/',
+  protocol: process.env.APP_PROTOCOL || 'http',
+  host: process.env.APP_HOST || 'localhost',
+  port: process.env.APP_PORT || '3000',
 };
 
 config.apps = [


### PR DESCRIPTION
## What

Logout on Alpha was returning the user to the authentication flow instead of the login page, because it was logging out of the application but not from SSO. This fixes that by hitting the auth0 logout endpoint, and supplying a `returnTo` value.

NB: will break any (non-local-dev) environments it is merged to unless the environment vars `APP_PROTOCOL`, `APP_HOST` and `APP_HOST` are present.

e.g.

```
APP_PROTOCOL=http
APP_HOST=localhost
APP_PORT=3000
```

## How to review

1. check out, docker down/up/in/out/etc
2. log in, log out, log in again
3. see that everything works as it should

