### PR TITLE
fixes repo select bug

### DIFF
--- a/app/assets/javascripts/modules/repo-description.js
+++ b/app/assets/javascripts/modules/repo-description.js
@@ -32,6 +32,7 @@ moj.Modules.repoDescription = {
     const descriptions = repoOptions.map(opt => opt.dataset.description);
 
     this.resetTypeahead();
+    this.$repoSlugTypeahead.val('');
 
     this.$repoSlugTypeahead.typeahead({
       order: 'asc',
@@ -47,8 +48,7 @@ moj.Modules.repoDescription = {
           this.repoSelected = true;
         },
         onCancel: () => {
-          this.$repoSlugTypeahead.val('');
-          this.resetTypeahead();
+          this.showOrgRepos();
         },
         onSubmit: () => this.repoSelected,
       },
@@ -60,7 +60,7 @@ moj.Modules.repoDescription = {
     this.$repoSlugSelect.hide();
     this.updateDescription('');
     $('.typeahead__result, .typeahead__cancel-button').remove();
-    $('.typeahead__container').removeClass('cancel');
+    $('.typeahead__container').removeClass('cancel result');
     $('#repo-results').addClass('js-hidden');
   },
 


### PR DESCRIPTION
## What

There was a bug with repo selection on the "Create app" page. If the typeahead failed to find anything, clearing it and starting again would stop it working at all until the page was refreshed. This fixes that by resetting it properly.

## How to review

1. go to `/apps/new`
2. start typing something in the repo box, clear it, start again, try this a few times
3. each time the typeahead should work as expected