### PR TITLE
remove the word app from app data source (temporary)

### DIFF
--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -23,7 +23,7 @@
       <ul class="list list-bullet">
         <li><a href="{{ url_for('users.list') }}">List all users</a></li>
         <li><a href="{{ url_for('apps.list') }}">List all apps</a></li>
-        <li><a href="{{ url_for('buckets.list') }}">List all app data sources</a></li>
+        <li><a href="{{ url_for('buckets.list') }}">List all data sources</a></li>
       </ul>
     </section>
   {% endif %}
@@ -36,7 +36,7 @@
 
   <section class="tab-panel">
     <div class="form-group">
-      <h2 class="heading-medium">{{ heading_prefix }} app data sources</h2>
+      <h2 class="heading-medium">{{ heading_prefix }} data sources</h2>
       {% if user.users3buckets.length %}
         <table class="form-group">
           <thead>
@@ -61,7 +61,7 @@
                   <a class="button button-secondary" href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">Manage data source access</a>
                   <form action="{{ url_for('buckets.delete', { id: users3bucket.s3bucket.id }) }}" method="post" class="inline-form">
                     <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
-                    <input type="submit" class="button button-secondary right js-confirm" value="Delete app data source" data-confirm-message="Are you sure you want to delete this app data source?">
+                    <input type="submit" class="button button-secondary right js-confirm" value="Delete data source" data-confirm-message="Are you sure you want to delete this data source?">
                   </form>
                 {% endif %}
               </td>
@@ -72,7 +72,7 @@
         <p>None</p>
       {% endif %}
 
-      <p><a class="button button-secondary" href="/buckets/new">Create new app data source</a></p>
+      <p><a class="button button-secondary" href="/buckets/new">Create new data source</a></p>
     </div>
   </section>
 

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -1,13 +1,13 @@
 {% extends "layouts/one-column.html" %}
 {% from "includes/yesno.html" import yes_no %}
 
-{% set page_title = "App data source: " + bucket.name %}
+{% set page_title = "Data source: " + bucket.name %}
 
 {% block main_column %}
 
 
 <h2 class="heading-medium">Users with admin access</h2>
-<p>{{ bucket.users3buckets.length }} user{%- if bucket.users3buckets.length != 1 -%}s are{% else %} is{% endif %} admin of this app data source</p>
+<p>{{ bucket.users3buckets.length }} user{%- if bucket.users3buckets.length != 1 -%}s are{% else %} is{% endif %} admin of this data source</p>
 
 {% if bucket.users3buckets.length %}
   <table class="form-group">
@@ -60,7 +60,7 @@
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />
       <div class="form-group">
-        <label class="form-label" for="user_id">Make user admin of this app data source</label>
+        <label class="form-label" for="user_id">Make user admin of this data source</label>
         <select class="form-control no-blank" id="user_id" name="user_id">
           <option value="">Select a user</option>
           {% for user in users_options %}
@@ -73,13 +73,13 @@
       </div>
     </form>
   {% else %}
-    <p>(All available users are already admin of this app data source.)</p>
+    <p>(All available users are already admin of this data source.)</p>
   {% endif %}
 
   <hr>
   <form action="{{ url_for('buckets.delete', { id: bucket.id }) }}" method="post" class="clearfix">
     <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
-    <input type="submit" class="button button-warning right js-confirm" value="Delete bucket" data-confirm-message="Are you sure you want to delete this bucket?">
+    <input type="submit" class="button button-warning right js-confirm" value="Delete data source" data-confirm-message="Are you sure you want to delete this data source?">
   </form>
 {% endif %}
 

--- a/app/templates/buckets/includes/new-bucket-name.html
+++ b/app/templates/buckets/includes/new-bucket-name.html
@@ -1,5 +1,5 @@
 <label class="form-label" for="new-datasource-name">
-  App data source (bucket) name
+  Data source (bucket) name
   <span class="form-hint">60 chars max, only lowercase letters, numbers, periods and hyphens, auto-prefixed with "{{ bucket_prefix }}"</span>
 </label>
 {% if error.error.name %}

--- a/app/templates/buckets/new.html
+++ b/app/templates/buckets/new.html
@@ -1,6 +1,6 @@
 {% extends "layouts/one-column.html" %}
 
-{% set page_title = "Create new app data source" %}
+{% set page_title = "Create new data source" %}
 
 {% block main_column %}
 


### PR DESCRIPTION
## What

For the upcoming user testing, @RobinL wants instances of "App data source" reworded to "Data source" so that the user journeys for creating data sources don't appear to be app data source specific.

To be reverted after user testing.

## How to review

1. Check that where it used to say "App data source" it now says "Data source" etc.