### PR TITLE
Fixed logout in dev/alpha

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -7,7 +7,7 @@ const uuid = require('uuid');
 
 
 function sso_logout_url() {
-  const returnTo = encodeURI(`${config.app.protocol}://${config.app.host}:${config.app.port}`);
+  const returnTo = encodeURI(`${config.app.protocol}://${config.app.host}`);
   return `https://${config.auth0.domain}${config.auth0.sso_logout_url}?returnTo=${returnTo}&client_id=${config.auth0.clientID}`;
 }
 

--- a/app/config.js
+++ b/app/config.js
@@ -14,8 +14,7 @@ config.app = {
   env: process.env.ENV || 'dev',
   asset_path: '/static/',
   protocol: process.env.APP_PROTOCOL || 'http',
-  host: process.env.APP_HOST || 'localhost',
-  port: process.env.APP_PORT || process.env.EXPRESS_PORT || 3000,
+  host: process.env.APP_HOST || 'localhost:3000',
 };
 
 config.apps = [


### PR DESCRIPTION
### What
When Auth0 redirect the user back to port `https://{host}:80` this
doesn't work as HTTPS traffic is on port `443`.

Removed `app.port` config (it can be passed as part of `app.host`
for when developing locally).

### How to review

1. Click logout
2. (the Auth0 client needs to have your test URL in the `Allowed Logout URLs` section)
3. You get logged out, without seeing and error
