### PR TITLE
Pass bucket prefix back to form on error when creating bucket

### DIFF
--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -28,6 +28,7 @@ exports.create_bucket = (req, res) => {
     .catch((error) => {
       res.render('buckets/new.html', {
         bucket: { name: req.body['new-datasource-name'] },
+        bucket_prefix: `${process.env.ENV}-`,
         error,
       });
     });

--- a/test/buckets/test-create.js
+++ b/test/buckets/test-create.js
@@ -28,4 +28,33 @@ describe('buckets/create', () => {
         assert.equal(redirect_url, url_for('buckets.details', { id: created_bucket.id }));
       });
   });
+
+  afterEach(() => {
+    delete process.env.ENV;
+  });
+
+  it('show an error if a bucket already exists with specified name', () => {
+    const form_data = {
+      'new-datasource-name': 'test-bucket',
+    };
+
+    const errors = {
+      name: 's3 bucket with this name already exists.',
+    };
+
+    process.env.ENV = 'test';
+
+    mock_api()
+      .post('/s3buckets/')
+      .reply(400, errors);
+
+    return dispatch(handlers.create_bucket, { body: form_data })
+      .then(({ redirect_url, template, context }) => {
+        assert.isUndefined(redirect_url);
+        assert.equal(template, 'buckets/new.html');
+        assert.deepEqual(context.error.error, errors);
+        assert.equal(context.bucket_prefix, 'test-');
+        assert.equal(context.bucket.name, 'test-bucket');
+      });
+  });
 });


### PR DESCRIPTION
* Added bucket prefix (`dev-` or `alpha-`) to template context on form error, because it was missing and resubmitting the form after an error would not add the prefix

## How to review

1. Create a bucket with the name of an existing bucket
2. See the form redisplayed with an error message
3. See that the prefix is still present