### PR TITLE
Remove cookie message from template

### DIFF
--- a/app/templates/govuk_template.html
+++ b/app/templates/govuk_template.html
@@ -17,14 +17,14 @@
     <!--[if lt IE 9]><script src="{{ asset_path }}javascripts/ie.js?0.22.1"></script><![endif]-->
 
     <link rel="shortcut icon" href="{{ asset_path }}images/favicon.ico?0.22.1" type="image/x-icon" />
-    
+
     <link rel="mask-icon" href="{{ asset_path }}images/gov.uk_logotype_crown.svg?0.22.1" color="#0b0c0c">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset_path }}images/apple-touch-icon-180x180.png?0.22.1">
     <link rel="apple-touch-icon" sizes="167x167" href="{{ asset_path }}images/apple-touch-icon-167x167.png?0.22.1">
     <link rel="apple-touch-icon" sizes="152x152" href="{{ asset_path }}images/apple-touch-icon-152x152.png?0.22.1">
     <link rel="apple-touch-icon" href="{{ asset_path }}images/apple-touch-icon.png?0.22.1">
 
-    
+
     <meta name="theme-color" content="#0b0c0c" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -44,13 +44,7 @@
       </div>
     </div>
 
-    <div id="global-cookie-message">
-      
-        {% block cookie_message %}{% endblock %}
-      
-    </div>
 
-    
     <header role="banner" id="global-header" class="{% block header_class %}{% endblock %}">
       <div class="header-wrapper">
         <div class="header-global">
@@ -64,7 +58,7 @@
         {% block proposition_header %}{% endblock %}
       </div>
     </header>
-    
+
 
     {% block after_header %}{% endblock %}
 
@@ -83,9 +77,9 @@
 
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
-              
+
                 {% block licence_message %}<p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>{% endblock %}
-              
+
             </div>
           </div>
 
@@ -102,7 +96,7 @@
 
     {% block body_end %}{% endblock %}
 
-    
+
     <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
   </body>
 </html>


### PR DESCRIPTION
## What

When logging in incognito the cookie bar shows on the site, though with no message since we haven't written one and the template doesn't have one. Additionally it's 2018 and our users are internal, so let's ditch it.

## How to review

1. Clear cookies or log in in an incognito window
2. See that no cyan bar appears at the top of the screen when you reach email verification or homepage