### PR TITLE
Prevent session leaks across requests

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -1,6 +1,6 @@
 const { App, Bucket, User } = require('../models');
 const { Repo } = require('../models/github');
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const config = require('../config');
 const { GithubAPIClient } = require('../api_clients/github');
 const { url_for } = require('../routes');

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -1,6 +1,6 @@
 const { Deployment, User } = require('../models');
 const config = require('../config');
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const passport = require('passport');
 const { url_for } = require('../routes');
 const uuid = require('uuid');

--- a/app/config.js
+++ b/app/config.js
@@ -149,11 +149,11 @@ config.sentry = {
 config.session = {
   cookie: {
     maxAge: ((maxAge) => {
-      if (isNaN(maxAge)) {
+      if (Number.isNaN(maxAge)) {
         return 1 * 60 * 60 * 1000; // 1 hours
       }
       return maxAge;
-    })(parseInt(process.env.COOKIE_MAXAGE)),
+    })(Number.parseInt(process.env.COOKIE_MAXAGE, 10)),
   },
   logFn: console.log, // eslint-disable-line no-console
   name: 'session',

--- a/app/config.js
+++ b/app/config.js
@@ -54,6 +54,10 @@ config.continuation_locals = {
   namespace: 'cpfrontend',
 };
 
+config.cookie = {
+  secret: process.env.COOKIE_SECRET || 'shh-its-a-secret',
+};
+
 config.ensure_login = {
   exclude: [
     /^\/callback/,
@@ -144,7 +148,7 @@ config.sentry = {
 
 config.session = {
   name: 'session',
-  secret: process.env.COOKIE_SECRET || 'shh-its-a-secret',
+  secret: config.cookie.secret,
   resave: false,
   saveUninitialized: false,
   logFn: console.log, // eslint-disable-line no-console

--- a/app/config.js
+++ b/app/config.js
@@ -85,7 +85,7 @@ config.js = {
 config.log = {
   requests: process.env.ENABLE_ACCESS_LOGS !== 'false',
   stream: process.stdout,
-  level: process.env.LOG_LEVEL || 'debug',
+  level: process.env.NODE_LOG_LEVEL || 'debug',
 };
 
 // order is important!
@@ -147,11 +147,19 @@ config.sentry = {
 };
 
 config.session = {
+  cookie: {
+    maxAge: ((maxAge) => {
+      if (isNaN(maxAge)) {
+        return 1 * 60 * 60 * 1000; // 1 hours
+      }
+      return maxAge;
+    })(parseInt(process.env.COOKIE_MAXAGE)),
+  },
+  logFn: console.log, // eslint-disable-line no-console
   name: 'session',
-  secret: config.cookie.secret,
   resave: false,
   saveUninitialized: false,
-  logFn: console.log, // eslint-disable-line no-console
+  secret: config.cookie.secret,
 };
 
 config.session_store = {

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -1,6 +1,6 @@
 const { ControlPanelAPIClient } = require('../api_clients/control_panel_api');
 const { KubernetesAPIClient } = require('../api_clients/kubernetes');
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 
 
 module.exports = (app, conf, log) => {

--- a/app/middleware/continuation-locals.js
+++ b/app/middleware/continuation-locals.js
@@ -1,4 +1,4 @@
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 
 
 module.exports = (app, conf, log) => {

--- a/app/middleware/cookie-parser.js
+++ b/app/middleware/cookie-parser.js
@@ -2,5 +2,5 @@ const cookie_parser = require('cookie-parser');
 
 module.exports = (app, conf, log) => {
   log.info('adding cookie-parser');
-  return cookie_parser();
+  return cookie_parser(conf.cookie.secret);
 };

--- a/app/middleware/flash-messages.js
+++ b/app/middleware/flash-messages.js
@@ -4,7 +4,7 @@ module.exports = (app, conf, log) => {
   return (req, res, next) => {
     if (req.session) {
       if (req.session.flash_messages) {
-        app.locals.messages = req.session.flash_messages;
+        res.locals.messages = req.session.flash_messages;
       }
       req.session.flash_messages = [];
     }

--- a/app/middleware/session.js
+++ b/app/middleware/session.js
@@ -1,4 +1,4 @@
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const session = require('express-session');
 const RedisStore = require('connect-redis')(session);
 const redislog = require('bole')('redis');

--- a/app/middleware/session.js
+++ b/app/middleware/session.js
@@ -17,22 +17,22 @@ module.exports = (app, conf, log) => {
   return [
     (req, res, next) => {
       const ns = cls.getNamespace(conf.continuation_locals.namespace);
-      const resume = ns.bind(next);
+      next = ns.bind(next); // eslint-disable-line no-param-reassign
       let tries = 3;
 
       function lookup_session(error) {
         if (error) {
-          return resume(error);
+          return next(error);
         }
 
         tries -= 1;
 
         if (req.session !== undefined) {
-          return resume();
+          return next();
         }
 
         if (tries < 0) {
-          return resume(new Error('session lookup failed'));
+          return next(new Error('session lookup failed'));
         }
 
         return session_middleware(req, res, lookup_session);

--- a/app/middleware/template-locals.js
+++ b/app/middleware/template-locals.js
@@ -1,10 +1,10 @@
 module.exports = (app, conf, log) => {
   log.info('adding template-locals');
   return (req, res, next) => {
-    app.locals.asset_path = conf.app.asset_path;
-    app.locals.current_user = req.user || null;
-    app.locals.env = process.env;
-    app.locals.req = req;
+    res.locals.asset_path = conf.app.asset_path;
+    res.locals.current_user = req.user;
+    res.locals.env = process.env;
+    res.locals.req = req;
     next();
   };
 };

--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -1,6 +1,6 @@
 const { APIError } = require('../api_clients/base');
 const base = require('./base');
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const config = require('../config');
 const { get_namespace } = require('../api_clients/kubernetes');
 

--- a/app/models/github.js
+++ b/app/models/github.js
@@ -1,4 +1,4 @@
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const config = require('../config');
 const { Model, ModelSet } = require('./base');
 

--- a/app/models/kubernetes.js
+++ b/app/models/kubernetes.js
@@ -1,7 +1,7 @@
 const base = require('./base');
 const config = require('../config');
 const { DoesNotExist } = require('./control_panel_api');
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 
 
 class Model extends base.Model {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "bluebird": "^3.5.1",
     "body-parser": "^1.18.2",
     "bole": "3.0.2",
+    "cls-hooked": "^4.2.2",
     "concat-files": "^0.1.1",
     "connect-ensure-login": "^0.1.1",
     "connect-redis": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "$([ \"x$NODE_RESTART\" == \"x0\" ] && echo node || echo nodemon ) ./app/server.js | bistre",
     "test": "mocha -C -R list --recursive",
     "collect-static": "node ./bin/collect-static.js | bistre",
-    "lint": "node node_modules/eslint/bin/eslint.js app || exit 0"
+    "lint": "node node_modules/eslint/bin/eslint.js app"
   },
   "repository": {
     "type": "git",

--- a/test/conftest.js
+++ b/test/conftest.js
@@ -1,4 +1,4 @@
-const cls = require('continuation-local-storage');
+const cls = require('cls-hooked');
 const config = require('../app/config');
 const { ControlPanelAPIClient } = require('../app/api_clients/control_panel_api');
 const { GithubAPIClient } = require('../app/api_clients/github');

--- a/yarn.lock
+++ b/yarn.lock
@@ -200,6 +200,12 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async-hook-jl@^1.7.6:
+  version "1.7.6"
+  resolved "https://registry.yarnpkg.com/async-hook-jl/-/async-hook-jl-1.7.6.tgz#4fd25c2f864dbaf279c610d73bf97b1b28595e68"
+  dependencies:
+    stack-chain "^1.3.7"
+
 async-listener@^0.6.0:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/async-listener/-/async-listener-0.6.9.tgz#51bc95e41095417f33922fb4dee4f232b3226488"
@@ -978,6 +984,14 @@ clone-response@1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+cls-hooked@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/cls-hooked/-/cls-hooked-4.2.2.tgz#ad2e9a4092680cdaffeb2d3551da0e225eae1908"
+  dependencies:
+    async-hook-jl "^1.7.6"
+    emitter-listener "^1.0.1"
+    semver "^5.4.1"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -1342,7 +1356,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-emitter-listener@^1.1.1:
+emitter-listener@^1.0.1, emitter-listener@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/emitter-listener/-/emitter-listener-1.1.1.tgz#e8bbbe8244bc8e0d0b4ef71cd14294c7f241c7ec"
   dependencies:
@@ -3985,6 +3999,10 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
@@ -4169,6 +4187,10 @@ sshpk@^1.7.0:
     ecc-jsbn "~0.1.1"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-chain@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/stack-chain/-/stack-chain-1.3.7.tgz#d192c9ff4ea6a22c94c4dd459171e3f00cea1285"
 
 stack-trace@0.0.9:
   version "0.0.9"


### PR DESCRIPTION
## What

The session sharing/leaking bug is difficult to diagnose, but my best guess is that we’ve been storing request scope data in `app.locals` when we should have stored them in `res.locals` (my bad).
`app.locals`, the name suggests, stores values in the scope of the app lifetime, which would be shared across requests.
`res.locals` is scoped to the current request and response.
I’ve changed the relevant references from `app.locals` to `res.locals`, which I think will fix the bug, but it’s hard to test automatically

Another potential source of the bug is the use of `continuation-local-storage`, but I think this is less likely. However, as a precaution, I upgraded to `cls-hooked`, a more up-to-date implementation.

Additionally, I've tweaked some cookie settings to set a default max-age for the session cookie.

## How to review

(Maybe)
1. Login as superuser A
2. Login in another browser as normal user B
3. Request another page as user A
4. See that user A still has access to superuser navigation
5. Request another page as user B
6. See that user B still does not have access to superuser navigation

Maybe fixes https://github.com/ministryofjustice/analytics-platform/issues/24