### PR TITLE
Adds breadcrumb component to main template and list pages

### DIFF
--- a/app/templates/apps/list.html
+++ b/app/templates/apps/list.html
@@ -1,14 +1,7 @@
 {% extends "layouts/one-column.html" %}
 
 {% set page_title = "Apps" %}
-
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-  <ol>
-    <li><a href="/">Home</a></li>
-  </ol>
-</div>
-{% endblock %}
+{% set breadcrumbs = [{text: 'Home', url: '/'}, {text: 'List all webapps'}] %}
 
 {% block main_column %}
 

--- a/app/templates/apps/list.html
+++ b/app/templates/apps/list.html
@@ -2,6 +2,14 @@
 
 {% set page_title = "Apps" %}
 
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <ol>
+    <li><a href="/">Home</a></li>
+  </ol>
+</div>
+{% endblock %}
+
 {% block main_column %}
 
 <p>{{ apps.length }} app{%- if apps.length != 1 -%}s{%- endif -%}</p>

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -1,14 +1,7 @@
 {% extends "layouts/one-column.html" %}
 
 {% set page_title = "App data sources" %}
-
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-  <ol>
-    <li><a href="/">Home</a></li>
-  </ol>
-</div>
-{% endblock %}
+{% set breadcrumbs = [{text: 'Home', url: '/'}, {text: 'List all data sources'}] %}
 
 {% block main_column %}
 

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -2,6 +2,14 @@
 
 {% set page_title = "App data sources" %}
 
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <ol>
+    <li><a href="/">Home</a></li>
+  </ol>
+</div>
+{% endblock %}
+
 {% block main_column %}
 
 <p>{{ buckets.length }} app data source{%- if buckets.length != 1 -%}s{%- endif -%}</p>

--- a/app/templates/layouts/one-column.html
+++ b/app/templates/layouts/one-column.html
@@ -1,5 +1,21 @@
 {% extends "layouts/base.html" %}
 
+{% macro breadcrumbs_list(crumbs) %}
+  {% if crumbs %}
+    <div class="breadcrumbs">
+      <ol>
+        {% for crumb in crumbs %}
+          {% if crumb.url %}
+            <li><a href="{{ crumb.url }}">{{ crumb.text }}</a></li>
+          {% else %}
+            <li aria-current="page">{{ crumb.text }}</li>
+          {% endif %}
+        {% endfor %}
+      </ol>
+    </div>
+  {% endif %}
+{% endmacro %}
+
 {% block page_title %}
   {{ page_title }} | Analytical Platform Control Panel
 {% endblock %}
@@ -8,7 +24,9 @@
 
 <main id="content" role="main">
 
-  {% block breadcrumbs %}{% endblock %}
+  {% if breadcrumbs %}
+    {{ breadcrumbs_list(breadcrumbs) }}
+  {% endif %}
 
   {% for message in messages %}
     <p class="flash-message">{{ message }}</p>

--- a/app/templates/layouts/one-column.html
+++ b/app/templates/layouts/one-column.html
@@ -8,6 +8,8 @@
 
 <main id="content" role="main">
 
+  {% block breadcrumbs %}{% endblock %}
+
   {% for message in messages %}
     <p class="flash-message">{{ message }}</p>
   {% endfor %}

--- a/app/templates/layouts/one-column.html
+++ b/app/templates/layouts/one-column.html
@@ -1,19 +1,17 @@
 {% extends "layouts/base.html" %}
 
 {% macro breadcrumbs_list(crumbs) %}
-  {% if crumbs %}
-    <div class="breadcrumbs">
-      <ol>
-        {% for crumb in crumbs %}
-          {% if crumb.url %}
-            <li><a href="{{ crumb.url }}">{{ crumb.text }}</a></li>
-          {% else %}
-            <li aria-current="page">{{ crumb.text }}</li>
-          {% endif %}
-        {% endfor %}
-      </ol>
-    </div>
-  {% endif %}
+  <div class="breadcrumbs">
+    <ol>
+      {% for crumb in crumbs %}
+        {% if crumb.url %}
+          <li><a href="{{ crumb.url }}">{{ crumb.text }}</a></li>
+        {% else %}
+          <li aria-current="page">{{ crumb.text }}</li>
+        {% endif %}
+      {% endfor %}
+    </ol>
+  </div>
 {% endmacro %}
 
 {% block page_title %}

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -1,14 +1,7 @@
 {% extends "layouts/one-column.html" %}
 
 {% set page_title = "Users" %}
-
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-  <ol>
-    <li><a href="/">Home</a></li>
-  </ol>
-</div>
-{% endblock %}
+{% set breadcrumbs = [{text: 'Home', url: '/'}, {text: 'List all users'}] %}
 
 {% block main_column %}
 

--- a/app/templates/users/list.html
+++ b/app/templates/users/list.html
@@ -2,6 +2,14 @@
 
 {% set page_title = "Users" %}
 
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <ol>
+    <li><a href="/">Home</a></li>
+  </ol>
+</div>
+{% endblock %}
+
 {% block main_column %}
 
 <p>{{ users.length }} user{%- if users.length != 1 -%}s{%- endif -%}</p>


### PR DESCRIPTION
## What

Adds the breadcrumb component from Elements to the template we use for all current pages, and implements it on the three superuser list pages. It can be added incrementally to other pages.

## How to review

1. log in as superuser
2. see a "Home" breadcrumb on any of the superuser function list pages