### PR TITLE
Silent SSO

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -41,7 +41,7 @@ exports.error_test = (req, res, next) => {
 
 
 exports.auth_callback = [
-  passport.authenticate('oidc'),
+  passport.authenticate('oidc', { failureRedirect: '/login?prompt=true' }),
   (req, res) => {
     res.redirect(url_for('users.verify_email'));
   },
@@ -57,6 +57,7 @@ exports.login = (req, res, next) => {
   } else {
     passport.authenticate('oidc', {
       state: uuid(),
+      prompt: req.query.prompt || 'none',
     })(req, res, next);
   }
 };


### PR DESCRIPTION
### What
Don't ask for user login if user is already logged in "central" SSO.

### How / Login workflows
#### Workflow 1:
0) User *not* logged in CP-UI / Logged in central SSO
1) User visits CP-UI
2) User is redirected to hosted login page
3) User is redirected to CP-UI `/callback` without being promped for login
(as already logged in)
4) User doesn't notice anything (silently logged in CP-UI)

#### Workflow 2:
0) User *not* logged in CP-UI / *Not* logged in central SSO
1) User visits CP-UI
2) User is redirected to CP-UI `/callback` with an error (`error=login_required`)
3) CP-UI redirects user to /login?prompt=true
4) User is redirected to hosted login page and this time is promped for login
5) User logs in
6) User is redirected to CP-UI `/callback` and logged in CP-UI

### Ticket
https://trello.com/c/eBHZ1MmB/690-3-silent-sso-for-control-panel


