### PR TITLE
New tab for data warehouse buckets

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -18,7 +18,7 @@ exports.new = (req, res, next) => {
         orgs: config.github.orgs,
         repos,
         bucket_prefix: `${process.env.ENV}-`,
-        buckets,
+        buckets: buckets.filter(bucket => !bucket.is_data_warehouse),
         errors: req.form_errors,
       });
     })

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -19,10 +19,17 @@ exports.home = (req, res, next) => {
   Promise.all([Deployment.list(), User.get(req.user.auth0_id)])
     .then(([tools, user]) => {
       ns.run(() => {
+        const is_warehouse = bucket => !!bucket.s3bucket.is_data_warehouse;
+        const warehouse_buckets = user.users3buckets.filter(bucket => is_warehouse(bucket));
+        const webapp_buckets = user.users3buckets.filter(bucket => !is_warehouse(bucket));
         res.render('base/home.html', {
           tools,
           rstudio_is_deploying,
           user,
+          buckets: {
+            warehouse: warehouse_buckets,
+            webapp: webapp_buckets,
+          },
         });
       });
     })

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -19,17 +19,18 @@ exports.home = (req, res, next) => {
   Promise.all([Deployment.list(), User.get(req.user.auth0_id)])
     .then(([tools, user]) => {
       ns.run(() => {
-        const is_warehouse = bucket => !!bucket.s3bucket.is_data_warehouse;
-        const warehouse_buckets = user.users3buckets.filter(bucket => is_warehouse(bucket));
-        const webapp_buckets = user.users3buckets.filter(bucket => !is_warehouse(bucket));
+        const buckets = user.users3buckets.reduce(function (buckets, bucket) {
+          const group = !!bucket.s3bucket.is_data_warehouse ? 'warehouse' : 'webapp';
+          buckets[group] = buckets[group] || [];
+          buckets[group].push(bucket);
+          return buckets;
+        }, {});
+
         res.render('base/home.html', {
           tools,
           rstudio_is_deploying,
           user,
-          buckets: {
-            warehouse: warehouse_buckets,
-            webapp: webapp_buckets,
-          },
+          buckets,
         });
       });
     })

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -19,11 +19,11 @@ exports.home = (req, res, next) => {
   Promise.all([Deployment.list(), User.get(req.user.auth0_id)])
     .then(([tools, user]) => {
       ns.run(() => {
-        const buckets = user.users3buckets.reduce(function (buckets, bucket) {
-          const group = !!bucket.s3bucket.is_data_warehouse ? 'warehouse' : 'webapp';
-          buckets[group] = buckets[group] || [];
-          buckets[group].push(bucket);
-          return buckets;
+        const buckets = user.users3buckets.reduce((groupedBuckets, bucket) => {
+          const group = bucket.s3bucket.is_data_warehouse ? 'warehouse' : 'webapp';
+          groupedBuckets[group] = groupedBuckets[group] || [];
+          groupedBuckets[group].push(bucket);
+          return groupedBuckets;
         }, {});
 
         res.render('base/home.html', {

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -11,8 +11,9 @@
       <li class="tab-superuser">Superuser</li>
     {% endif %}
     <li class="tab-analytical-tools">Analytical tools</li>
+    <li class="tab-warehouse-data">Warehouse data</li>
     {% if current_user.is_superuser %}
-      <li class="tab-data">Data</li>
+      <li class="tab-webapp-data">Webapp data</li>
       <li class="tab-webapps">Webapps</li>
     {% endif %}
   </ul>
@@ -34,47 +35,52 @@
     {% include 'tools/includes/list.html' %}
   </section>
 
-  <section class="tab-panel">
-    <div class="form-group">
-      <h2 class="heading-medium">{{ heading_prefix }} data sources</h2>
-      {% if user.users3buckets.length %}
-        <table class="form-group">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>User has admin access</th>
-              <th>User has read/write access</th>
-              <td><span class="visuallyhidden">Actions</span></td>
-            </tr>
-          </thead>
-          {% for users3bucket in user.users3buckets %}
-            <tr>
-              <td><a href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">{{ users3bucket.s3bucket.name }}</a></td>
-              <td>
-                {{ yes_no(users3bucket.is_admin) }}
-              </td>
-              <td>
-                {{ yes_no(users3bucket.access_level, 'readwrite') }}
-              </td>
-              <td class="align-right no-wrap">
-                {% if users3bucket.is_admin %}
-                  <a class="button button-secondary" href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">Manage data source access</a>
-                  <form action="{{ url_for('buckets.delete', { id: users3bucket.s3bucket.id }) }}" method="post" class="inline-form">
-                    <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
-                    <input type="submit" class="button button-secondary right js-confirm" value="Delete data source" data-confirm-message="Are you sure you want to delete this data source?">
-                  </form>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </table>
-      {% else %}
-        <p>None</p>
-      {% endif %}
+  {% set data_tabs = ['warehouse', 'webapp'] %}
+  {% for data_tab in data_tabs %}
+    {% if data_tab == "warehouse" or current_user.is_superuser %}
+      <section class="tab-panel">
+        <div class="form-group">
+          <h2 class="heading-medium">{{ heading_prefix }} {{ data_tab }} data sources</h2>
+          {% if buckets[data_tab].length %}
+            <table class="form-group">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>User has admin access</th>
+                  <th>User has read/write access</th>
+                  <td><span class="visuallyhidden">Actions</span></td>
+                </tr>
+              </thead>
+              {% for users3bucket in buckets[data_tab] %}
+                <tr>
+                  <td><a href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">{{ users3bucket.s3bucket.name }}</a></td>
+                  <td>
+                    {{ yes_no(users3bucket.is_admin) }}
+                  </td>
+                  <td>
+                    {{ yes_no(users3bucket.access_level, 'readwrite') }}
+                  </td>
+                  <td class="align-right no-wrap">
+                    {% if users3bucket.is_admin %}
+                      <a class="button button-secondary" href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">Manage {{ data_tab }} data source access</a>
+                      <form action="{{ url_for('buckets.delete', { id: users3bucket.s3bucket.id }) }}" method="post" class="inline-form">
+                        <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
+                        <input type="submit" class="button button-secondary right js-confirm" value="Delete {{ data_tab }} data source" data-confirm-message="Are you sure you want to delete this {{ data_tab }} data source?">
+                      </form>
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </table>
+          {% else %}
+            <p>None</p>
+          {% endif %}
 
-      <p><a class="button button-secondary" href="/buckets/new">Create new data source</a></p>
-    </div>
-  </section>
+          <p><a class="button button-secondary" href="/buckets/new">Create new {{ data_tab }} data source</a></p>
+        </div>
+      </section>
+    {% endif %}
+  {% endfor %}
 
   <section class="tab-panel">
     <div class="form-group">

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -7,8 +7,6 @@
 {% block main_column %}
 
 <p>{{ buckets.length }} data source{%- if buckets.length != 1 -%}s{%- endif -%}</p>
-<!-- <p>{{ warehouse_buckets.length }} warehouse data source{%- if warehouse_buckets.length != 1 -%}s{%- endif -%}</p>
-<p>{{ app_buckets.length }} app data source{%- if app_buckets.length != 1 -%}s{%- endif -%}</p> -->
 
 {% if buckets.length %}
   <table class="list">

--- a/app/templates/buckets/list.html
+++ b/app/templates/buckets/list.html
@@ -1,31 +1,37 @@
 {% extends "layouts/one-column.html" %}
+{% from "includes/yesno.html" import yes_no %}
 
-{% set page_title = "App data sources" %}
+{% set page_title = "Data sources" %}
 {% set breadcrumbs = [{text: 'Home', url: '/'}, {text: 'List all data sources'}] %}
 
 {% block main_column %}
 
-<p>{{ buckets.length }} app data source{%- if buckets.length != 1 -%}s{%- endif -%}</p>
+<p>{{ buckets.length }} data source{%- if buckets.length != 1 -%}s{%- endif -%}</p>
+<!-- <p>{{ warehouse_buckets.length }} warehouse data source{%- if warehouse_buckets.length != 1 -%}s{%- endif -%}</p>
+<p>{{ app_buckets.length }} app data source{%- if app_buckets.length != 1 -%}s{%- endif -%}</p> -->
 
 {% if buckets.length %}
   <table class="list">
     <thead>
       <tr>
         <td>ID</td>
-        <th>App data source name</th>
+        <th>Data source name</th>
+        <th>Type</th>
         <th><span class="visuallyhidden">Actions</span></th>
       </tr>
     </thead>
     <tbody>
       {% for bucket in buckets %}
+        {% set bucket_type = yes_no(bucket.is_data_warehouse, true, 'warehouse', 'app') %}
         <tr>
           <td>{{ bucket.id }}</td>
           <td><a href="{{ url_for('buckets.details', { id: bucket.id }) }}">{{ bucket.name }}</a></td>
+          <td>{{ bucket_type }}</td>
           <td class="align-right">
             {% if current_user_is_bucket_admin or current_user.is_superuser %}
               <form action="{{ url_for('buckets.delete', { id: bucket.id }) }}" method="post" class="inline-form">
                 <input type="hidden" id="redirect" name="redirect" value="{{ url_for('buckets.list') }}">
-                <input type="submit" class="button button-secondary right js-confirm" value="Delete app data source" data-confirm-message="Are you sure you want to delete this app data source?">
+                <input type="submit" class="button button-secondary right js-confirm" value="Delete {{ bucket_type }} data source" data-confirm-message="Are you sure you want to delete this {{ bucket_type }} data source?">
               </form>
             {% endif %}
           </td>
@@ -36,7 +42,7 @@
 {% endif %}
 
 <div class="form-group">
-  <a href="{{ url_for('buckets.new') }}" class="button button-secondary">Create new app data source</a>
+  <a href="{{ url_for('buckets.new') }}" class="button button-secondary">Create new data source</a>
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## What

Create a new tab in the CP UI for "data warehouse" S3 buckets, and differentiate these from "webapp data" S3 buckets. The former tab to be visible to all users.

## How to review

1. Log in as a superuser
2. Create two new buckets
3. Use the API to make one of these new buckets a warehouse bucket (set `is_data_warehouse` to `true`)
4. Refresh the UI homepage and see that the warehouse bucket is on the warehouse buckets tab and the other is on the webapp data tab
5. Use the API to downgrade your user to a non-superuser and log in again
6. See that you are able to view the "Warehouse data" tab, and that the warehouse bucket you created is visible there

