### PR TITLE
Data warehouse bucket page enhancements

### DIFF
--- a/app/assets/javascripts/modules/access-panels.js
+++ b/app/assets/javascripts/modules/access-panels.js
@@ -18,6 +18,6 @@ moj.Modules.accessPanels = {
 
   togglePanel($panel) {
     $panel.toggleClass('js-hidden');
-    $panel.siblings('.js-change-access-level').toggle();
+    $panel.siblings(`.${this.buttonClass}`).toggle();
   },
 };

--- a/app/assets/javascripts/modules/access-panels.js
+++ b/app/assets/javascripts/modules/access-panels.js
@@ -1,5 +1,6 @@
 moj.Modules.accessPanels = {
   buttonClass: 'js-change-access-level',
+  panelClass: 'change-data-access-level-panel',
 
   init() {
     if ($(`.${this.buttonClass}`).length) {
@@ -9,6 +10,7 @@ moj.Modules.accessPanels = {
 
   bindEvents() {
     $(`.${this.buttonClass}`).on('click', (e) => {
+      this.closeOpenPanels();
       this.togglePanel($(e.target).siblings('.panel'));
     });
     $('.js-close-panel').on('click', (e) => {
@@ -19,5 +21,11 @@ moj.Modules.accessPanels = {
   togglePanel($panel) {
     $panel.toggleClass('js-hidden');
     $panel.siblings(`.${this.buttonClass}`).toggle();
+  },
+
+  closeOpenPanels() {
+    $(`.${this.panelClass}:not(.js-hidden)`).each((n, panel) => {
+      this.togglePanel($(panel));
+    });
   },
 };

--- a/app/assets/javascripts/modules/access-panels.js
+++ b/app/assets/javascripts/modules/access-panels.js
@@ -1,0 +1,23 @@
+moj.Modules.accessPanels = {
+  buttonClass: 'js-change-access-level',
+
+  init() {
+    if ($(`.${this.buttonClass}`).length) {
+      this.bindEvents();
+    }
+  },
+
+  bindEvents() {
+    $(`.${this.buttonClass}`).on('click', (e) => {
+      this.togglePanel($(e.target).siblings('.panel'));
+    });
+    $('.js-close-panel').on('click', (e) => {
+      this.togglePanel($(e.target).closest('.panel'));
+    });
+  },
+
+  togglePanel($panel) {
+    $panel.toggleClass('js-hidden');
+    $panel.siblings('.js-change-access-level').toggle();
+  },
+};

--- a/app/assets/javascripts/modules/user-typeahead.js
+++ b/app/assets/javascripts/modules/user-typeahead.js
@@ -1,0 +1,64 @@
+moj.Modules.userTypeahead = {
+  userSelectName: 'user_id',
+  userTypeaheadName: 'user_typeahead',
+
+  init() {
+    this.$select = $(`#${this.userSelectName}`);
+
+    if (this.$select.length) {
+      this.$form = this.$select.closest('form');
+      this.$userTypeahead = this.$form.find(`#${this.userTypeaheadName}`);
+      this.initTypeahead();
+      this.bindEvents();
+    }
+  },
+
+  bindEvents() {
+    this.$userTypeahead.on('keyup', () => {
+      this.updateSelect();
+    });
+  },
+
+  initTypeahead() {
+    const userOptions = Array.from(this.$select.find('option:gt(0)'));
+    this.users = userOptions.map(opt => opt.text);
+
+    this.$select.hide();
+
+    this.$userTypeahead.typeahead({
+      order: 'asc',
+      maxItem: 0,
+      source: {
+        data: this.users,
+      },
+      callback: {
+        onClickAfter: () => {
+          this.updateSelect();
+        },
+        onCancel: () => {
+          this.resetSelect();
+        },
+      },
+    });
+  },
+
+  updateSelect() {
+    const userText = this.$userTypeahead.val();
+    const userIndex = this.users.indexOf(userText);
+
+    if (userIndex > 0) {
+      this.selectOption(userIndex + 1);
+    } else {
+      this.resetSelect();
+    }
+  },
+
+  resetSelect() {
+    this.selectOption(0);
+  },
+
+  selectOption(index) {
+    this.$select.find('option').attr('selected', null);
+    this.$select.find(`option:eq(${index})`).attr('selected', 'selected');
+  },
+};

--- a/app/assets/javascripts/modules/user-typeahead.js
+++ b/app/assets/javascripts/modules/user-typeahead.js
@@ -7,7 +7,9 @@ moj.Modules.userTypeahead = {
 
     if (this.$select.length) {
       this.$form = this.$select.closest('form');
+      this.$formSubmit = this.$form.find('input[type="submit"]');
       this.$userTypeahead = this.$form.find(`#${this.userTypeaheadName}`);
+      this.$accessLevelPanel = $('#data-access-level-panel');
       this.initTypeahead();
       this.bindEvents();
     }
@@ -24,6 +26,7 @@ moj.Modules.userTypeahead = {
     this.users = userOptions.map(opt => opt.text);
 
     this.$select.hide();
+    this.setFormDisabled(true);
 
     this.$userTypeahead.typeahead({
       order: 'asc',
@@ -48,6 +51,7 @@ moj.Modules.userTypeahead = {
 
     if (userIndex > 0) {
       this.selectOption(userIndex + 1);
+      this.setFormDisabled(false);
     } else {
       this.resetSelect();
     }
@@ -55,10 +59,20 @@ moj.Modules.userTypeahead = {
 
   resetSelect() {
     this.selectOption(0);
+    this.setFormDisabled(true);
   },
 
   selectOption(index) {
     this.$select.find('option').attr('selected', null);
     this.$select.find(`option:eq(${index})`).attr('selected', 'selected');
+  },
+
+  setFormDisabled(state) {
+    this.$formSubmit.prop('disabled', state);
+    if (state) {
+      this.$accessLevelPanel.addClass('js-hidden').find('input[type="radio"]:eq(0)').prop('checked', 'checked');
+    } else {
+      this.$accessLevelPanel.removeClass('js-hidden');
+    }
   },
 };

--- a/app/assets/sass/app.scss
+++ b/app/assets/sass/app.scss
@@ -17,6 +17,7 @@ $path: "/static/images/";
 @import 'local/forms';
 @import 'local/tabs';
 @import 'local/tables';
+@import 'local/panels';
 @import 'local/buttons';
 @import 'local/typography';
 @import 'local/messages';

--- a/app/assets/sass/local/buttons.scss
+++ b/app/assets/sass/local/buttons.scss
@@ -11,3 +11,33 @@
 .button-warning {
   @include core-16;
 }
+
+button.js-close-panel {
+  display: block;
+  position: relative;
+  float: right;
+  text-indent: 200%;
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: pointer;
+  border: none;
+  background-color: $grey-3;
+  border-radius: 50%;
+  width: 30px;
+  height: 30px;
+
+  &:after {
+    content: '\00d7';
+    font-size: 30px;
+    position: absolute;
+    text-align: center;
+    width: 30px;
+    height: 30px;
+    left: -25px;
+    top: -3px;
+  }
+
+  &:hover {
+    background-color: $grey-2;
+  }
+}

--- a/app/assets/sass/local/panels.scss
+++ b/app/assets/sass/local/panels.scss
@@ -1,0 +1,5 @@
+.change-data-access-level-panel {
+  padding-top: 0;
+  padding-bottom: 0;
+  text-align: left;
+}

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -42,13 +42,10 @@ exports.create_bucket = (req, res) => {
 exports.bucket_details = (req, res, next) => {
   Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
     .then(([bucket, apps, users]) => {
-      const current_user_is_bucket_admin = bucket.has_admin(req.user.auth0_id);
-
       res.render('buckets/details.html', {
         bucket,
         apps_options: apps.exclude(bucket.apps),
         users_options: users.exclude(bucket.users),
-        current_user_is_bucket_admin,
       });
     })
     .catch(next);

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -42,10 +42,13 @@ exports.create_bucket = (req, res) => {
 exports.bucket_details = (req, res, next) => {
   Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
     .then(([bucket, apps, users]) => {
+      const current_user_is_bucket_admin = bucket.has_admin(req.user.auth0_id);
+
       res.render('buckets/details.html', {
         bucket,
         apps_options: apps.exclude(bucket.apps),
         users_options: users.exclude(bucket.users),
+        current_user_is_bucket_admin,
       });
     })
     .catch(next);

--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -187,16 +187,6 @@ class Bucket extends Model {
   get users3buckets() {
     return new ModelSet(UserS3Bucket, this.data.users3buckets);
   }
-
-  has_admin(user_id) {
-    const match_users3buckets = this.data.users3buckets.filter(us => us.user.auth0_id === user_id);
-    let user_has_admin = false;
-
-    if (match_users3buckets[0] && match_users3buckets[0].is_admin) {
-      user_has_admin = true;
-    }
-    return user_has_admin;
-  }
 }
 
 exports.Bucket = Bucket;
@@ -225,6 +215,10 @@ class User extends Model {
 
   get kubernetes_namespace() {
     return get_namespace(this.data.username);
+  }
+
+  is_bucket_admin(bucket_id) {
+    return this.users3buckets.filter(u => u.s3bucket.id === bucket_id && u.is_admin).length > 0;
   }
 }
 

--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -188,9 +188,14 @@ class Bucket extends Model {
     return new ModelSet(UserS3Bucket, this.data.users3buckets);
   }
 
-  has_admin(user_id) { // eslint-disable-line class-methods-use-this, no-unused-vars
-    return true;
-    // TODO: remove this and return real value once perms have been implemented
+  has_admin(user_id) {
+    const match_users3buckets = this.data.users3buckets.filter(us => us.user.auth0_id === user_id);
+    let user_has_admin = false;
+
+    if (match_users3buckets[0] && match_users3buckets[0].is_admin) {
+      user_has_admin = true;
+    }
+    return user_has_admin;
   }
 }
 

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -7,7 +7,6 @@
 
 {% block main_column %}
 
-
 <h2 class="heading-medium">Data access group</h2>
 <p>{{ bucket.users3buckets.length }} user{%- if bucket.users3buckets.length != 1 -%}s have{% else %} has{% endif %} access to this {{ bucket_type }} data source</p>
 
@@ -17,7 +16,8 @@
       <tr>
         <th>User</th>
         <th>User access level</th>
-        {% if bucket.has_admin(current_user) or current_user.is_superuser %}
+        {# % if current_user_is_bucket_admin or current_user.is_superuser % #}
+        {% if current_user_is_bucket_admin %}
           <th>
             <span class="visuallyhidden">Actions</span>
           </th>
@@ -35,7 +35,8 @@
               {{ users3bucket.access_level }}
             {% endif %}
           </td>
-          {% if bucket.has_admin(current_user) or current_user.is_superuser %}
+          {# % if current_user_is_bucket_admin or current_user.is_superuser % #}
+          {% if current_user_is_bucket_admin %}
             <td class="align-right">
 
               <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">
@@ -90,7 +91,8 @@
 
 <!-- <h1 class="heading-large">{{ current_user_is_bucket_admin }} - TODO: YOU ARE HERE</h1> -->
 
-{% if current_user_is_bucket_admin or current_user.is_superuser %}
+{# % if current_user_is_bucket_admin or current_user.is_superuser % #}
+{% if current_user_is_bucket_admin %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -16,7 +16,7 @@
       <tr>
         <th>User</th>
         <th>User access level</th>
-        {% if current_user_is_bucket_admin or current_user.is_superuser %}
+        {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
           <th>
             <span class="visuallyhidden">Actions</span>
           </th>
@@ -34,7 +34,7 @@
               {{ users3bucket.access_level }}
             {% endif %}
           </td>
-          {% if current_user_is_bucket_admin or current_user.is_superuser %}
+          {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
             <td class="align-right">
 
               <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">
@@ -47,15 +47,15 @@
                     <fieldset>
                       <legend class="visuallyhidden">Data access level</legend>
                       <div class="multiple-choice">
-                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readonly" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="readonly" {% if users3bucket.access_level == 'readonly' %}checked{% endif %}>
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readonly" name="data_access_level" value="readonly" {% if users3bucket.access_level == 'readonly' %}checked{% endif %}>
                         <label for="users3bucket_{{ users3bucket.id }}_data_access_level-readonly">Read only</label>
                       </div>
                       <div class="multiple-choice">
-                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readwrite" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="readwrite" {% if users3bucket.access_level == 'readwrite' and users3bucket.is_admin == false %}checked{% endif %}>
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readwrite" name="data_access_level" value="readwrite" {% if users3bucket.access_level == 'readwrite' and users3bucket.is_admin == false %}checked{% endif %}>
                         <label for="users3bucket_{{ users3bucket.id }}_data_access_level-readwrite">Read/write</label>
                       </div>
                       <div class="multiple-choice">
-                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-admin" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="admin" {% if users3bucket.is_admin %}checked{% endif %}>
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-admin" name="data_access_level" value="admin" {% if users3bucket.is_admin %}checked{% endif %}>
                         <label for="users3bucket_{{ users3bucket.id }}_data_access_level-admin">Admin</label>
                       </div>
                     </fieldset>
@@ -87,7 +87,7 @@
   <p>None</p>
 {% endif %}
 
-{% if current_user_is_bucket_admin or current_user.is_superuser %}
+{% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -34,8 +34,7 @@
               {{ users3bucket.access_level }}
             {% endif %}
           </td>
-          {# % if current_user_is_bucket_admin or current_user.is_superuser % #}
-          {% if current_user_is_bucket_admin %}
+          {% if current_user_is_bucket_admin or current_user.is_superuser %}
             <td class="align-right">
 
               <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -27,7 +27,7 @@
     <tbody>
       {% for users3bucket in bucket.users3buckets %}
         <tr>
-          <td><a class="{% if current_user.auth0_id == users3bucket.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', { id: users3bucket.user.auth0_id }) }}">{{ users3bucket.user.name }}</a></td>
+          <td><a class="{% if current_user.auth0_id == users3bucket.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', { id: users3bucket.user.auth0_id }) }}">{% if users3bucket.user.name %}{{ users3bucket.user.name }} {% endif %}({{ users3bucket.user.username }})</a></td>
           <td>{{ yes_no(users3bucket.access_level, 'readwrite') }}</td>
           <td class="align-right">
             {% if bucket.has_admin(current_user) or current_user.is_superuser %}
@@ -63,10 +63,21 @@
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />
       <div class="form-group">
         <label class="form-label" for="user_id">Make user admin of this {{ bucket_type }} data source</label>
+
+        <div class="typeahead__container">
+          <div class="typeahead__field">
+            <span class="typeahead__query">
+              <input id="user_typeahead" class="form-control form-control-1-2" name="user_typeahead" type="search" autocomplete="off" placeholder="Start typing to find a user..." value="{{ req.body.user_typeahead }}">
+            </span>
+          </div>
+        </div>
+
         <select class="form-control no-blank" id="user_id" name="user_id">
           <option value="">Select a user</option>
           {% for user in users_options %}
-            <option value="{{ user.auth0_id }}">{{ user.name }}</option>
+            {% if user.auth0_id and user.auth0_id != "jenkins" %}
+              <option value="{{ user.auth0_id }}">{% if user.name %}{{ user.name }} {% endif %}({{ user.username }})</option>
+            {% endif %}
           {% endfor %}
         </select>
       </div>

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -8,46 +8,78 @@
 {% block main_column %}
 
 
-<h2 class="heading-medium">Users with admin access</h2>
-<p>{{ bucket.users3buckets.length }} user{%- if bucket.users3buckets.length != 1 -%}s are{% else %} is{% endif %} admin of this {{ bucket_type }} data source</p>
+<h2 class="heading-medium">Data access group</h2>
+<p>{{ bucket.users3buckets.length }} user{%- if bucket.users3buckets.length != 1 -%}s have{% else %} has{% endif %} access to this {{ bucket_type }} data source</p>
 
 {% if bucket.users3buckets.length %}
-  <table class="bucket-admins form-group">
+  <table class="bucket-users form-group">
     <thead>
       <tr>
         <th>User</th>
-        <th>User has read/write access</th>
-        <th>
-          {% if bucket.has_admin(current_user) or current_user.is_superuser %}
+        <th>User access level</th>
+        {% if bucket.has_admin(current_user) or current_user.is_superuser %}
+          <th>
             <span class="visuallyhidden">Actions</span>
-          {% endif %}
-        </th>
+          </th>
+        {% endif %}
       </tr>
     </thead>
     <tbody>
       {% for users3bucket in bucket.users3buckets %}
         <tr>
           <td><a class="{% if current_user.auth0_id == users3bucket.user.auth0_id %}highlight-current{% endif %}" href="{{ url_for('users.details', { id: users3bucket.user.auth0_id }) }}">{% if users3bucket.user.name %}{{ users3bucket.user.name }} {% endif %}({{ users3bucket.user.username }})</a></td>
-          <td>{{ yes_no(users3bucket.access_level, 'readwrite') }}</td>
-          <td class="align-right">
-            {% if bucket.has_admin(current_user) or current_user.is_superuser %}
-              <!-- Button to change access level -->
-              <form action="{{ url_for('users3buckets.update', { id: users3bucket.id }) }}" method="post" class="inline-form clearfix">
-                <input type="hidden" name="access_level" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'readonly', 'readwrite') }}" />
-
-                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { id: bucket.id }) }}" />
-
-                <input type="submit" class="js-confirm button button-secondary" value="{{ yes_no(users3bucket.access_level, 'readwrite', 'Revoke', 'Grant') }} read/write access" />
-              </form>
-
-              <!-- Button to revoke access -->
-              <form action="{{ url_for('users3buckets.delete', { id: users3bucket.id }) }}" method="post" class="inline-form clearfix">
-                <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { id: bucket.id }) }}">
-
-                <input type="submit" class="js-confirm button button-secondary" value="Revoke admin access" />
-              </form>
+          <td>
+            {% if(users3bucket.is_admin) %}
+              admin
+            {% else %}
+              {{ users3bucket.access_level }}
             {% endif %}
           </td>
+          {% if bucket.has_admin(current_user) or current_user.is_superuser %}
+            <td class="align-right">
+
+              <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">
+
+                <button class="js-close-panel">Close panel</button>
+
+                <form action="{{ url_for('users3buckets.update', { id: users3bucket.id }) }}" method="post" class="inline-form clearfix">
+                  <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { id: bucket.id }) }}" />
+                  <div class="form-group">
+                    <fieldset>
+                      <legend class="visuallyhidden">Data access level</legend>
+                      <div class="multiple-choice">
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readonly" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="readonly" {% if users3bucket.access_level == 'readonly' %}checked{% endif %}>
+                        <label for="users3bucket_{{ users3bucket.id }}_data_access_level-readonly">Read only</label>
+                      </div>
+                      <div class="multiple-choice">
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-readwrite" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="readwrite" {% if users3bucket.access_level == 'readwrite' and users3bucket.is_admin == false %}checked{% endif %}>
+                        <label for="users3bucket_{{ users3bucket.id }}_data_access_level-readwrite">Read/write</label>
+                      </div>
+                      <div class="multiple-choice">
+                        <input type="radio" id="users3bucket_{{ users3bucket.id }}_data_access_level-admin" name="users3bucket_{{ users3bucket.id }}_data_access_level" value="admin" {% if users3bucket.is_admin %}checked{% endif %}>
+                        <label for="users3bucket_{{ users3bucket.id }}_data_access_level-admin">Admin</label>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div class="form-group">
+                    <input type="submit" class="button button-secondary" value="Save" />
+                  </div>
+                </form>
+
+                <hr>
+                <div class="form-group js-revoke-access" id="users3bucket_{{ users3bucket.id }}_revoke-access">
+                  <form action="{{ url_for('users3buckets.delete', { id: users3bucket.id }) }}" method="post" class="inline-form clearfix">
+                    <input type="hidden" name="redirect_to" value="{{ url_for('buckets.details', { id: bucket.id }) }}">
+
+                    <input type="submit" class="js-confirm button button-warning" value="Revoke access" />
+                  </form>
+                </div>
+              </div>
+
+              <button class="button button-secondary js-change-access-level" id="users3bucket_{{ users3bucket.id }}_change-data-access-level">Edit access level</button>
+
+            </td>
+          {% endif %}
         </tr>
       {% endfor %}
     </tbody>
@@ -56,13 +88,14 @@
   <p>None</p>
 {% endif %}
 
+<!-- <h1 class="heading-large">{{ current_user_is_bucket_admin }} - TODO: YOU ARE HERE</h1> -->
 
 {% if current_user_is_bucket_admin or current_user.is_superuser %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />
       <div class="form-group">
-        <label class="form-label" for="user_id">Make user admin of this {{ bucket_type }} data source</label>
+        <label class="form-label" for="user_id">Grant access to this data to other users</label>
 
         <div class="typeahead__container">
           <div class="typeahead__field">
@@ -81,12 +114,31 @@
           {% endfor %}
         </select>
       </div>
+
+      <div class="form-group panel panel-border-narrow js-hidden" id="data-access-level-panel">
+        <fieldset>
+          <legend>Data access level</legend>
+          <div class="multiple-choice">
+            <input type="radio" id="data_access_level-readonly" name="data_access_level" value="readonly" checked>
+            <label for="data_access_level-readonly">Read only</label>
+          </div>
+          <div class="multiple-choice">
+            <input type="radio" id="data_access_level-readwrite" name="data_access_level" value="readwrite">
+            <label for="data_access_level-readwrite">Read/write</label>
+          </div>
+          <div class="multiple-choice">
+            <input type="radio" id="data_access_level-admin" name="data_access_level" value="admin">
+            <label for="data_access_level-admin">Admin</label>
+          </div>
+        </fieldset>
+      </div>
+
       <div class="form-group">
-        <input type="submit" class="button button-secondary" value="Grant admin access">
+        <input type="submit" class="button button-secondary" value="Grant access">
       </div>
     </form>
   {% else %}
-    <p>(All available users are already admin of this {{ bucket_type }} data source.)</p>
+    <p>(All available users already have access to this data source.)</p>
   {% endif %}
 
   <hr>

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -16,8 +16,7 @@
       <tr>
         <th>User</th>
         <th>User access level</th>
-        {# % if current_user_is_bucket_admin or current_user.is_superuser % #}
-        {% if current_user_is_bucket_admin %}
+        {% if current_user_is_bucket_admin or current_user.is_superuser %}
           <th>
             <span class="visuallyhidden">Actions</span>
           </th>
@@ -89,10 +88,7 @@
   <p>None</p>
 {% endif %}
 
-<!-- <h1 class="heading-large">{{ current_user_is_bucket_admin }} - TODO: YOU ARE HERE</h1> -->
-
-{# % if current_user_is_bucket_admin or current_user.is_superuser % #}
-{% if current_user_is_bucket_admin %}
+{% if current_user_is_bucket_admin or current_user.is_superuser %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -128,9 +128,12 @@
             <input type="radio" id="data_access_level-readwrite" name="data_access_level" value="readwrite">
             <label for="data_access_level-readwrite">Read/write</label>
           </div>
-          <div class="multiple-choice">
+          <div class="multiple-choice" data-target="admin-information">
             <input type="radio" id="data_access_level-admin" name="data_access_level" value="admin">
             <label for="data_access_level-admin">Admin</label>
+          </div>
+          <div class="panel panel-border-narrow js-hidden" id="admin-information">
+            <p><strong>NOTE:</strong> Making user admin will allow them to confer access rights on additional users.</p>
           </div>
         </fieldset>
       </div>

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -3,13 +3,22 @@ const { url_for } = require('../routes');
 
 
 exports.create = (req, res, next) => {
-  const { user_id, bucket_id } = req.body;
+  const { user_id, bucket_id, data_access_level } = req.body;
+  let access_level = 'readonly';
+  let is_admin = false;
+
+  if (data_access_level !== 'readonly') {
+    access_level = 'readwrite';
+  }
+  if (data_access_level === 'admin') {
+    is_admin = true;
+  }
 
   new UserS3Bucket({
     user: user_id,
     s3bucket: bucket_id,
-    access_level: 'readonly',
-    is_admin: false,
+    access_level,
+    is_admin,
   })
     .create()
     .then(() => {
@@ -20,11 +29,22 @@ exports.create = (req, res, next) => {
 
 exports.update = (req, res, next) => {
   const users3bucket_id = req.params.id;
-  const { access_level, redirect_to } = req.body;
+  const { redirect_to } = req.body;
+  const users3bucket_access_level = req.body[`users3bucket_${users3bucket_id}_data_access_level`];
+  let access_level = 'readonly';
+  let is_admin = false;
+
+  if (users3bucket_access_level === 'admin') {
+    is_admin = true;
+  }
+  if (users3bucket_access_level !== 'readonly') {
+    access_level = 'readwrite';
+  }
 
   new UserS3Bucket({
     id: users3bucket_id,
     access_level,
+    is_admin,
   })
     .update()
     .then(() => { res.redirect(redirect_to); })

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -29,15 +29,14 @@ exports.create = (req, res, next) => {
 
 exports.update = (req, res, next) => {
   const users3bucket_id = req.params.id;
-  const { redirect_to } = req.body;
-  const users3bucket_access_level = req.body[`users3bucket_${users3bucket_id}_data_access_level`];
+  const { redirect_to, data_access_level } = req.body;
   let access_level = 'readonly';
   let is_admin = false;
 
-  if (users3bucket_access_level === 'admin') {
+  if (data_access_level === 'admin') {
     is_admin = true;
   }
-  if (users3bucket_access_level !== 'readonly') {
+  if (data_access_level !== 'readonly') {
     access_level = 'readwrite';
   }
 

--- a/codecept/tests/create-and-delete-data-source.js
+++ b/codecept/tests/create-and-delete-data-source.js
@@ -50,7 +50,7 @@ Scenario('Check data source page', (I) => {
   I.waitForText('Data source:', 5, 'h1');
   I.see(test_bucket_name, 'h1');
   I.say('Data source created');
-  I.see(test_user_name, 'table.bucket-admins');
+  I.see(test_user_name, 'table.bucket-users');
   I.say('Test user is admin for data source');
 });
 

--- a/codecept/tests/create-data-source-and-app-then-link-then-delete.js
+++ b/codecept/tests/create-data-source-and-app-then-link-then-delete.js
@@ -52,7 +52,7 @@ Scenario('Check data source', (I) => {
   I.waitForText('Data source:', 5, 'h1');
   I.see(test_bucket_name, 'h1');
   I.say('Data source created');
-  I.see(test_user_name, 'table.bucket-admins');
+  I.see(test_user_name, 'table.bucket-users');
   I.say('Test user is admin for data source');
 });
 

--- a/test/users3buckets/test-create.js
+++ b/test/users3buckets/test-create.js
@@ -7,17 +7,18 @@ describe('users3buckets.create', () => {
   it('posts a users3bucket', () => {
     const bucket_id = 42;
     const user_id = 'github|123';
+    const data_access_level = 'readonly';
 
     const post_users3buckets = mock_api()
       .post('/users3buckets/', {
         user: user_id,
         s3bucket: bucket_id,
-        access_level: 'readonly',
+        access_level: data_access_level,
         is_admin: false,
       })
       .reply(201);
 
-    return dispatch(handlers.create, { body: { user_id, bucket_id } })
+    return dispatch(handlers.create, { body: { user_id, bucket_id, data_access_level } })
       .then(({ redirect_url }) => {
         assert(post_users3buckets.isDone());
         assert.equal(redirect_url, url_for('buckets.details', { id: bucket_id }));

--- a/test/users3buckets/test-update.js
+++ b/test/users3buckets/test-update.js
@@ -6,18 +6,23 @@ const handlers = require('../../app/users3buckets/handlers');
 describe('users3buckets.update', () => {
   it('patches the specified users3bucket', () => {
     const users3bucket_id = 42;
-    const access_level = 'readonly';
+    const data_access_level = 'readonly';
     const redirect_to = 'buckets/123';
+    const users3bucket_key = `users3bucket_${users3bucket_id}_data_access_level`;
+
+    const patchData = {
+      id: users3bucket_id,
+      access_level: data_access_level,
+      is_admin: false,
+    };
 
     const patch_users3buckets = mock_api()
-      .patch(`/users3buckets/${users3bucket_id}/`, {
-        id: users3bucket_id,
-        access_level,
-      })
+      .patch(`/users3buckets/${users3bucket_id}/`, patchData)
       .reply(201);
 
     const params = { id: users3bucket_id };
-    const body = { access_level, redirect_to };
+    let body = { redirect_to };
+    body[users3bucket_key] = data_access_level;
 
     return dispatch(handlers.update, { params, body })
       .then(({ redirect_url }) => {

--- a/test/users3buckets/test-update.js
+++ b/test/users3buckets/test-update.js
@@ -8,7 +8,6 @@ describe('users3buckets.update', () => {
     const users3bucket_id = 42;
     const data_access_level = 'readonly';
     const redirect_to = 'buckets/123';
-    const users3bucket_key = `users3bucket_${users3bucket_id}_data_access_level`;
 
     const patchData = {
       id: users3bucket_id,
@@ -21,8 +20,7 @@ describe('users3buckets.update', () => {
       .reply(201);
 
     const params = { id: users3bucket_id };
-    let body = { redirect_to };
-    body[users3bucket_key] = data_access_level;
+    const body = { redirect_to, data_access_level };
 
     return dispatch(handlers.update, { params, body })
       .then(({ redirect_url }) => {


### PR DESCRIPTION
## What

Covers the first part of https://github.com/ministryofjustice/analytics-platform-control-panel/issues/108 - "Data warehouse bucket details page"

## How to review

Check that the changes described for the bucket details page are implemented and working.

1. Users in access group table (and in typeahead - see below) should show `name` and `username`
2. Users in access group table should display their access level - read only, read/write, or admin

![screen shot 2018-03-27 at 16 15 26](https://user-images.githubusercontent.com/988436/37976757-1e330540-31da-11e8-9b37-103d20f43509.png)

The following apply when viewing a warehouse bucket to which you have admin access. (Note, if you are a superuser you will have automatic admin access to everything.)

1. Typeahead for adding users to data access group
![image](https://user-images.githubusercontent.com/988436/37976782-2fb26022-31da-11e8-87ad-72d7654ad804.png)
2. You should be able to grant the three levels of access to users - users given 'admin' access will also be able to grant/revoke access to other users
![image](https://user-images.githubusercontent.com/988436/37976814-3ef2a3ee-31da-11e8-92fc-7e75c1fe35d3.png)
3. You should be able to edit the access level for a given current user, or revoke access entirely
![image](https://user-images.githubusercontent.com/988436/37976842-4fd7af56-31da-11e8-9914-60bdf5c37dfd.png)


Note there are no protections against:
* removing your own access from a bucket
* removing the last user from a bucket
* removing the last admin from a bucket