### PR TITLE
Warehouse tab

### DIFF
--- a/app/assets/javascripts/modules/modals.js
+++ b/app/assets/javascripts/modules/modals.js
@@ -1,0 +1,26 @@
+moj.Modules.modals = {
+  triggerClass: 'js-modal-trigger',
+  contentClass: 'js-modal-content',
+
+  init() {
+    if ($(`.${this.triggerClass}`).length) {
+      this.bindEvents();
+    }
+  },
+
+  bindEvents() {
+    $(`.${this.triggerClass}`).on('click', (event) => {
+      this.triggerModal($(event.target));
+    });
+    $(document).on($.modal.AFTER_CLOSE, () => {
+      $('.modal').remove();
+    });
+  },
+
+  triggerModal($trigger) {
+    const content_handle = $trigger.data('content');
+    const content = $(`#content-${content_handle}`).html();
+    $('body').append(`<div class="modal" id="modal-${content_handle}">${content}</div>`);
+    $(`#modal-${content_handle}`).modal();
+  },
+};

--- a/app/assets/sass/app.scss
+++ b/app/assets/sass/app.scss
@@ -22,6 +22,7 @@ $path: "/static/images/";
 @import 'local/typography';
 @import 'local/messages';
 @import 'local/icons';
+@import 'local/modal';
 @import 'local/spinner';
 @import 'local/utilities';
 @import 'local/debug';

--- a/app/assets/sass/local/modal.scss
+++ b/app/assets/sass/local/modal.scss
@@ -1,0 +1,31 @@
+.js-modal-trigger {
+  display: inline-block;
+  position: relative;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background-color: $grey-3;
+  top: 4px;
+
+  span {
+    @include visually-hidden;
+  }
+
+  &:before {
+    content: '?';
+    position: absolute;
+    font-style: normal;
+    margin-left: 10px;
+    width: 20px;
+    height: 20px;
+    text-indent: center;
+    cursor: pointer;
+    left: -4px;
+    top: 1px;
+  }
+
+  &:hover {
+    background-color: $grey-2;
+  }
+}

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -51,6 +51,7 @@ exports.bucket_details = (req, res, next) => {
     .catch(next);
 };
 
+
 exports.delete = (req, res, next) => {
   let bucket_name;
   Bucket.get(req.params.id)
@@ -62,6 +63,15 @@ exports.delete = (req, res, next) => {
       const redirect_to = req.body.redirect || url_for('base.home');
       req.session.flash_messages.push(`Bucket "${bucket_name}" deleted`);
       res.redirect(redirect_to);
+    })
+    .catch(next);
+};
+
+
+exports.aws = (req, res, next) => {
+  Bucket.get(req.params.id)
+    .then((bucket) => {
+      res.redirect(bucket.location_url);
     })
     .catch(next);
 };

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -20,6 +20,7 @@ exports.new_bucket = (req, res) => {
 
 
 exports.create_bucket = (req, res) => {
+  let new_bucket;
   new Bucket({
     name: req.body['new-datasource-name'],
     apps3buckets: [],
@@ -27,7 +28,14 @@ exports.create_bucket = (req, res) => {
   })
     .create()
     .then((bucket) => {
-      res.redirect(url_for('buckets.details', { id: bucket.id }));
+      new_bucket = bucket;
+      return User.get(req.user.auth0_id);
+    })
+    .then((user) => {
+      req.session.passport.user.users3buckets = user.data.users3buckets;
+    })
+    .then(() => {
+      res.redirect(url_for('buckets.details', { id: new_bucket.id }));
     })
     .catch((error) => {
       res.render('buckets/new.html', {

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -1,4 +1,4 @@
-const { App, Bucket, User } = require('../models');
+const { Bucket, User } = require('../models');
 const { url_for } = require('../routes');
 
 
@@ -40,13 +40,12 @@ exports.create_bucket = (req, res) => {
 
 
 exports.bucket_details = (req, res, next) => {
-  Promise.all([Bucket.get(req.params.id), App.list(), User.list()])
-    .then(([bucket, apps, users]) => {
+  Promise.all([Bucket.get(req.params.id), User.list()]) // need to include App.list() in future
+    .then(([bucket, users]) => { // need to include apps in future
       res.render('buckets/details.html', {
         bucket,
-        apps_options: apps.exclude(bucket.apps),
         users_options: users.exclude(bucket.users),
-      });
+      }); // need to include apps_options: apps.exclude(bucket.apps) in future
     })
     .catch(next);
 };

--- a/app/buckets/routes.js
+++ b/app/buckets/routes.js
@@ -7,4 +7,5 @@ module.exports = [
   { name: 'create', pattern: '/buckets/new', handler: handlers.create_bucket, method: 'POST' },
   { name: 'details', pattern: '/buckets/:id', handler: handlers.bucket_details },
   { name: 'delete', method: 'POST', pattern: '/buckets/:id/delete', handler: handlers.delete },
+  { name: 'aws', pattern: '/buckets/aws/:id', handler: handlers.aws },
 ];

--- a/app/config.js
+++ b/app/config.js
@@ -178,6 +178,7 @@ config.static = {
       join(node_modules, 'govuk_frontend_toolkit'),
       join(node_modules, 'jquery/dist'),
       join(node_modules, 'jquery-typeahead/dist'),
+      join(node_modules, 'jquery-modal'),
     ],
     '/static/images/icons': [
       join(node_modules, 'govuk_frontend_toolkit/images'),

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -12,8 +12,8 @@
       <li class="tab-superuser">Superuser</li>
     {% endif %}
     <li class="tab-analytical-tools">Analytical tools</li>
+    <li class="tab-warehouse-data">Warehouse data</li>
     {% if current_user.is_superuser %}
-      <li class="tab-warehouse-data">Warehouse data</li>
       <li class="tab-webapp-data">Webapp data</li>
       <li class="tab-webapps">Webapps</li>
     {% endif %}
@@ -36,9 +36,9 @@
     {% include 'tools/includes/list.html' %}
   </section>
 
-  {% if current_user.is_superuser %}
     {% set data_tabs = ['warehouse', 'webapp'] %}
     {% for data_tab in data_tabs %}
+  {% if current_user.is_superuser or data_tab == 'warehouse' %}
       <section class="tab-panel">
         <div class="form-group">
           <h2 class="heading-medium">{{ heading_prefix }} {{ data_tab }} data sources</h2>
@@ -47,7 +47,17 @@
               <thead>
                 <tr>
                   <th>Name</th>
-                  <th>Your access level <em>?</em></th>
+                  <th>
+                    Your access level <em class="js-modal-trigger" data-content="access-levels"><span>What's this?</span></em>
+                    <div class="js-hidden js-modal-content" id="content-access-levels">
+                      <h3 class="heading-small">Data access levels</h3>
+                      <ul class="list list-bullet">
+                        <li><strong>Read only</strong> - user can read the data but not modify it</li>
+                        <li><strong>Read/write</strong> - user can read, modify and delete the data</li>
+                        <li><strong>Admin</strong> - user can read, modify and delete the data, and also grant/modify/revoke access rights to this data for other users</li>
+                      </ul>
+                    </div>
+                  </th>
                   <td><span class="visuallyhidden">Actions</span></td>
                 </tr>
               </thead>
@@ -74,8 +84,10 @@
           <p><a class="button button-secondary" href="{{ url_for('buckets.new', { type: data_tab }) }}">Create new {{ data_tab }} data source</a></p>
         </div>
       </section>
+      {% endif %}
     {% endfor %}
 
+  {% if current_user.is_superuser %}
     <section class="tab-panel">
       <div class="form-group">
         <h2 class="heading-medium">{{ heading_prefix }} apps</h2>

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -12,8 +12,8 @@
       <li class="tab-superuser">Superuser</li>
     {% endif %}
     <li class="tab-analytical-tools">Analytical tools</li>
+    <li class="tab-warehouse-data">Warehouse data</li>
     {% if current_user.is_superuser %}
-      <li class="tab-warehouse-data">Warehouse data</li>
       <li class="tab-webapp-data">Webapp data</li>
       <li class="tab-webapps">Webapps</li>
     {% endif %}
@@ -38,7 +38,7 @@
 
   {% set data_tabs = ['warehouse', 'webapp'] %}
   {% for data_tab in data_tabs %}
-    {% if current_user.is_superuser %}
+    {% if current_user.is_superuser or data_tab == 'warehouse' %}
       <section class="tab-panel">
         <div class="form-group">
           <h2 class="heading-medium">{{ heading_prefix }} {{ data_tab }} data sources</h2>

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -12,8 +12,8 @@
       <li class="tab-superuser">Superuser</li>
     {% endif %}
     <li class="tab-analytical-tools">Analytical tools</li>
-    <li class="tab-warehouse-data">Warehouse data</li>
     {% if current_user.is_superuser %}
+      <li class="tab-warehouse-data">Warehouse data</li>
       <li class="tab-webapp-data">Webapp data</li>
       <li class="tab-webapps">Webapps</li>
     {% endif %}
@@ -36,9 +36,9 @@
     {% include 'tools/includes/list.html' %}
   </section>
 
-    {% set data_tabs = ['warehouse', 'webapp'] %}
-    {% for data_tab in data_tabs %}
-  {% if current_user.is_superuser or data_tab == 'warehouse' %}
+  {% set data_tabs = ['warehouse', 'webapp'] %}
+  {% for data_tab in data_tabs %}
+    {% if current_user.is_superuser %}
       <section class="tab-panel">
         <div class="form-group">
           <h2 class="heading-medium">{{ heading_prefix }} {{ data_tab }} data sources</h2>
@@ -84,8 +84,8 @@
           <p><a class="button button-secondary" href="{{ url_for('buckets.new', { type: data_tab }) }}">Create new {{ data_tab }} data source</a></p>
         </div>
       </section>
-      {% endif %}
-    {% endfor %}
+    {% endif %}
+  {% endfor %}
 
   {% if current_user.is_superuser %}
     <section class="tab-panel">

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -12,7 +12,9 @@
       <li class="tab-superuser">Superuser</li>
     {% endif %}
     <li class="tab-analytical-tools">Analytical tools</li>
-    <li class="tab-warehouse-data">Warehouse data</li>
+    {% if env.ENV == 'dev' or current_user.is_superuser %}
+      <li class="tab-warehouse-data">Warehouse data</li>
+    {% endif %}
     {% if current_user.is_superuser %}
       <li class="tab-webapp-data">Webapp data</li>
       <li class="tab-webapps">Webapps</li>
@@ -38,7 +40,7 @@
 
   {% set data_tabs = ['warehouse', 'webapp'] %}
   {% for data_tab in data_tabs %}
-    {% if current_user.is_superuser or data_tab == 'warehouse' %}
+    {% if current_user.is_superuser or (data_tab == 'warehouse' and env.ENV == 'dev') %}
       <section class="tab-panel">
         <div class="form-group">
           <h2 class="heading-medium">{{ heading_prefix }} {{ data_tab }} data sources</h2>

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -47,8 +47,7 @@
               <thead>
                 <tr>
                   <th>Name</th>
-                  <th>User has admin access</th>
-                  <th>User has read/write access</th>
+                  <th>Your access level <em>?</em></th>
                   <td><span class="visuallyhidden">Actions</span></td>
                 </tr>
               </thead>
@@ -56,19 +55,14 @@
                 <tr>
                   <td><a href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">{{ users3bucket.s3bucket.name }}</a></td>
                   <td>
-                    {{ yes_no(users3bucket.is_admin) }}
-                  </td>
-                  <td>
-                    {{ yes_no(users3bucket.access_level, 'readwrite') }}
+                    {% if users3bucket.is_admin %}
+                      admin
+                    {% else %}
+                      {{ users3bucket.access_level }}
+                    {% endif %}
                   </td>
                   <td class="align-right no-wrap">
-                    {% if users3bucket.is_admin %}
-                      <a class="button button-secondary" href="{{ url_for('buckets.details', { id: users3bucket.s3bucket.id }) }}">Manage {{ data_tab }} data source access</a>
-                      <form action="{{ url_for('buckets.delete', { id: users3bucket.s3bucket.id }) }}" method="post" class="inline-form">
-                        <input type="hidden" id="redirect" name="redirect" value="{{ url_for('base.home') }}">
-                        <input type="submit" class="button button-secondary right js-confirm" value="Delete {{ data_tab }} data source" data-confirm-message="Are you sure you want to delete this {{ data_tab }} data source?">
-                      </form>
-                    {% endif %}
+                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">View data in AWS</a>
                   </td>
                 </tr>
               {% endfor %}
@@ -135,4 +129,3 @@
   {% endif %}
 
 {% endblock %}
-

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -16,7 +16,7 @@
       <tr>
         <th>User</th>
         <th>User access level</th>
-        {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
+        {% if current_user.is_bucket_admin(bucket.id) %}
           <th>
             <span class="visuallyhidden">Actions</span>
           </th>
@@ -34,7 +34,7 @@
               {{ users3bucket.access_level }}
             {% endif %}
           </td>
-          {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
+          {% if current_user.is_bucket_admin(bucket.id) %}
             <td class="align-right">
 
               <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">
@@ -87,7 +87,7 @@
   <p>None</p>
 {% endif %}
 
-{% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
+{% if current_user.is_bucket_admin(bucket.id) %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -3,7 +3,7 @@
 
 {% set bucket_type = 'warehouse' if bucket.is_data_warehouse else 'webapp' %}
 {% set page_title = bucket_type | capitalize + " data source: " + bucket.name %}
-{% set breadcrumbs = [{text: 'Home', url: '/'}, {text: 'Data source details'}] %}
+{% set breadcrumbs = [{text: 'Home', url: '/'}, {text: bucket_type | capitalize + " data", url: '/#' + bucket_type | capitalize + '%20data'}, {text: 'Data source details'}] %}
 
 {% block main_column %}
 

--- a/app/templates/buckets/new.html
+++ b/app/templates/buckets/new.html
@@ -1,6 +1,6 @@
 {% extends "layouts/one-column.html" %}
 
-{% set page_title = "Create new " + type + " data source" %}
+{% set page_title = "Create new secure data storage folder" %}
 {% set breadcrumbs = [{text: 'Home', url: '/'}, {text: page_title}] %}
 
 {% block main_column %}
@@ -11,7 +11,7 @@
 
   <div class="text">
     {% if type == "warehouse" %}
-      <p class="lede">Create a new folder to store data, and an associated data access group.</p>
+      <p class="lede">Create a new folder to store data, with an associated data access group.</p>
       <p><em>Only you will have access to this data until you add colleagues to the data access group.</em></p>
     {% elseif type == "webapp" %}
       <p class="lede">Lorem ipsum copy about webapp buckets</p>

--- a/app/templates/includes/head.html
+++ b/app/templates/includes/head.html
@@ -1,3 +1,4 @@
 <link rel="stylesheet" href="/static/jquery.typeahead.min.css" type="text/css">
+<link rel="stylesheet" href="/static/jquery.modal.min.css" type="text/css">
 <!--[if lte IE 8]><link href="/static/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/static/stylesheets/app.css" media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/templates/includes/scripts.html
+++ b/app/templates/includes/scripts.html
@@ -1,6 +1,7 @@
 <!-- Javascript -->
 <script src="/static/jquery.min.js"></script>
 <script src="/static/jquery.typeahead.min.js"></script>
+<script src="/static/jquery.modal.min.js"></script>
 <script src="/static/javascripts/govuk/show-hide-content.js"></script>
 
 <script src="/static/javascripts/transpiled_app.js"></script>

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -21,9 +21,7 @@ exports.create = (req, res, next) => {
     is_admin,
   })
     .create()
-    .then(() => {
-      return User.get(req.user.auth0_id);
-    })
+    .then(() => User.get(req.user.auth0_id))
     .then((user) => {
       req.session.passport.user.users3buckets = user.data.users3buckets;
     })
@@ -52,9 +50,7 @@ exports.update = (req, res, next) => {
     is_admin,
   })
     .update()
-    .then(() => {
-      return User.get(req.user.auth0_id);
-    })
+    .then(() => User.get(req.user.auth0_id))
     .then((user) => {
       req.session.passport.user.users3buckets = user.data.users3buckets;
     })

--- a/app/users3buckets/handlers.js
+++ b/app/users3buckets/handlers.js
@@ -1,4 +1,4 @@
-const { UserS3Bucket } = require('../models');
+const { UserS3Bucket, User } = require('../models');
 const { url_for } = require('../routes');
 
 
@@ -21,6 +21,12 @@ exports.create = (req, res, next) => {
     is_admin,
   })
     .create()
+    .then(() => {
+      return User.get(req.user.auth0_id);
+    })
+    .then((user) => {
+      req.session.passport.user.users3buckets = user.data.users3buckets;
+    })
     .then(() => {
       res.redirect(url_for('buckets.details', { id: bucket_id }));
     })
@@ -46,6 +52,12 @@ exports.update = (req, res, next) => {
     is_admin,
   })
     .update()
+    .then(() => {
+      return User.get(req.user.auth0_id);
+    })
+    .then((user) => {
+      req.session.passport.user.users3buckets = user.data.users3buckets;
+    })
     .then(() => { res.redirect(redirect_to); })
     .catch(next);
 };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "govuk_frontend_toolkit": "7.0.0",
     "govuk_template_jinja": "0.22.1",
     "jquery": "^3.2.1",
+    "jquery-modal": "^0.9.1",
     "jquery-typeahead": "^2.10.4",
     "morgan": "^1.9.0",
     "node-sass": "^4.5.3",

--- a/test/buckets/test-details.js
+++ b/test/buckets/test-details.js
@@ -28,7 +28,8 @@ describe('buckets/details', () => {
         assert.equal(template, 'buckets/details.html');
 
         assert.deepEqual(context.bucket, expected.bucket);
-        assert.deepEqual(context.apps_options, expected.apps);
+        // this was removed temporarily in the handler
+        // assert.deepEqual(context.apps_options, expected.apps);
         assert.deepEqual(context.users_options, expected.users);
       });
   });

--- a/test/users3buckets/test-create.js
+++ b/test/users3buckets/test-create.js
@@ -2,11 +2,13 @@ const { assert } = require('chai');
 const { dispatch, mock_api, url_for } = require('../conftest');
 const handlers = require('../../app/users3buckets/handlers');
 
+const user = require('../fixtures/user');
+
 
 describe('users3buckets.create', () => {
   it('posts a users3bucket', () => {
     const bucket_id = 42;
-    const user_id = 'github|123';
+    const user_id = user.auth0_id;
     const data_access_level = 'readonly';
 
     const post_users3buckets = mock_api()
@@ -18,8 +20,23 @@ describe('users3buckets.create', () => {
       })
       .reply(201);
 
-    return dispatch(handlers.create, { body: { user_id, bucket_id, data_access_level } })
+    const get_user = mock_api()
+      .get(`/users/${escape(user_id)}/`)
+      .reply(200, user);
+
+    const req = {
+      body: { user_id, bucket_id, data_access_level },
+      user,
+      session: {
+        passport: {
+          user: {}
+        }
+      },
+    };
+
+    return dispatch(handlers.create, req)
       .then(({ redirect_url }) => {
+        assert(get_user.isDone());
         assert(post_users3buckets.isDone());
         assert.equal(redirect_url, url_for('buckets.details', { id: bucket_id }));
       });

--- a/test/users3buckets/test-create.js
+++ b/test/users3buckets/test-create.js
@@ -39,6 +39,7 @@ describe('users3buckets.create', () => {
         assert(get_user.isDone());
         assert(post_users3buckets.isDone());
         assert.equal(redirect_url, url_for('buckets.details', { id: bucket_id }));
+        assert.deepEqual(req.session.passport.user.users3buckets, user.users3buckets);
       });
   });
 });

--- a/test/users3buckets/test-update.js
+++ b/test/users3buckets/test-update.js
@@ -44,6 +44,7 @@ describe('users3buckets.update', () => {
         assert(get_user.isDone());
         assert(patch_users3buckets.isDone());
         assert.equal(redirect_url, redirect_to);
+        assert.deepEqual(req.session.passport.user.users3buckets, user.users3buckets);
       });
   });
 });

--- a/test/users3buckets/test-update.js
+++ b/test/users3buckets/test-update.js
@@ -2,6 +2,8 @@ const { assert } = require('chai');
 const { dispatch, mock_api } = require('../conftest');
 const handlers = require('../../app/users3buckets/handlers');
 
+const user = require('../fixtures/user');
+
 
 describe('users3buckets.update', () => {
   it('patches the specified users3bucket', () => {
@@ -19,11 +21,27 @@ describe('users3buckets.update', () => {
       .patch(`/users3buckets/${users3bucket_id}/`, patchData)
       .reply(201);
 
-    const params = { id: users3bucket_id };
-    const body = { redirect_to, data_access_level };
+    const get_user = mock_api()
+      .get(`/users/${escape(user.auth0_id)}/`)
+      .reply(200, user);
 
-    return dispatch(handlers.update, { params, body })
+    const req = {
+      user,
+      body: {
+        redirect_to,
+        data_access_level,
+      },
+      params: { id: users3bucket_id },
+      session: {
+        passport: {
+          user: {}
+        }
+      },
+    };
+
+    return dispatch(handlers.update, req)
       .then(({ redirect_url }) => {
+        assert(get_user.isDone());
         assert(patch_users3buckets.isDone());
         assert.equal(redirect_url, redirect_to);
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2726,6 +2726,10 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
+jquery-modal@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/jquery-modal/-/jquery-modal-0.9.1.tgz#f22f13f0efa5ea3f2afaeb7981c1e20114c9d2f2"
+
 jquery-typeahead@^2.10.4:
   version "2.10.4"
   resolved "https://registry.yarnpkg.com/jquery-typeahead/-/jquery-typeahead-2.10.4.tgz#9a46d74fda419b0724ae0ff3663f800d280bc6ce"


### PR DESCRIPTION
## What

See section marked 'Main /data_warehouse page' [here](https://github.com/ministryofjustice/analytics-platform-control-panel/issues/108)

This PR reveals the "Warehouse data" tab on the CP homepage to non-superusers, but only on the dev environment, so that it can be tested by @RobinL before releasing it to users.

## How to review

1. log in as a non-superuser (make sure to set `ENV=dev` in `.env`)
2. see that the "Warehouse data" tab is now available
![image](https://user-images.githubusercontent.com/988436/38431961-e0f90eb8-39bd-11e8-83e2-d65bb3861adf.png)
3. click through to the Warehouse data tab and create a bucket or two
4. see that they are listed on the Warehouse data tab
5. see that the modal popup explaining the access levels appears when the `?` icon is clicked

