### PR TITLE
Re-enable access level editing for superusers

### DIFF
--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -16,7 +16,7 @@
       <tr>
         <th>User</th>
         <th>User access level</th>
-        {% if current_user.is_bucket_admin(bucket.id) %}
+        {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
           <th>
             <span class="visuallyhidden">Actions</span>
           </th>
@@ -34,7 +34,7 @@
               {{ users3bucket.access_level }}
             {% endif %}
           </td>
-          {% if current_user.is_bucket_admin(bucket.id) %}
+          {% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
             <td class="align-right">
 
               <div class="form-group change-data-access-level-panel panel panel-border-narrow js-hidden" id="users3bucket_{{ users3bucket.id }}_change-data-access-level-panel">
@@ -87,7 +87,7 @@
   <p>None</p>
 {% endif %}
 
-{% if current_user.is_bucket_admin(bucket.id) %}
+{% if current_user.is_bucket_admin(bucket.id) or current_user.is_superuser %}
   {% if users_options.length %}
     <form action="{{ url_for('users3buckets.create') }}" method="post">
       <input type="hidden" name="bucket_id" value="{{ bucket.id }}" />


### PR DESCRIPTION
## What

Superusers should be able to edit access levels to any buckets for any user.

## How to review

1. It's just a jump to the left
2. And then a step to the ra-ra-ra-ra-right
3. Put your hands on your hips
4. Log in as a superuser and see if you can change another user's access level to a bucket of which you are not an admin