### PR TITLE
link buckets to S3 per environment

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -31,6 +31,7 @@ exports.home = (req, res, next) => {
           rstudio_is_deploying,
           user,
           buckets,
+          aws_url: config.aws.login_url,
         });
       });
     })

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -31,7 +31,6 @@ exports.home = (req, res, next) => {
           rstudio_is_deploying,
           user,
           buckets,
-          aws_url: config.aws.login_url,
         });
       });
     })

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -78,7 +78,21 @@ exports.delete = (req, res, next) => {
 exports.aws = (req, res, next) => {
   Bucket.get(req.params.id)
     .then((bucket) => {
-      res.redirect(bucket.location_url);
+      if (bucket.location_url) {
+        res.redirect(bucket.location_url);
+      } else {
+        const aws_urls = {
+          alpha: 'https://alpha-analytics-moj.eu.auth0.com/samlp/NpfImg4P3ynU6HFx7ivYmqUZWQHfwi3Y',
+          dev: 'https://dev-analytics-moj.eu.auth0.com/samlp/GCTaoFKOc8MjhcfNJym2Fv9aD1YXoewt',
+        };
+        if (aws_urls[process.env.ENV]) {
+          res.redirect(aws_urls[process.env.ENV]);
+        } else {
+          const fragment = `${(bucket.is_data_warehouse ? 'Warehouse' : 'Webapp')}%20data`;
+          req.session.flash_messages.push(`No AWS URL found for environment: ${process.env.ENV}`);
+          res.redirect(`${url_for('base.home')}#${fragment}`);
+        }
+      }
     })
     .catch(next);
 };

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -1,4 +1,5 @@
 const { Bucket, User } = require('../models');
+const config = require('../config');
 const { url_for } = require('../routes');
 
 
@@ -81,13 +82,7 @@ exports.aws = (req, res, next) => {
       if (bucket.location_url) {
         res.redirect(bucket.location_url);
       } else {
-        if (config.aws.login_url) {
-          res.redirect(config.aws.login_url);
-        } else {
-          const fragment = `${(bucket.is_data_warehouse ? 'Warehouse' : 'Webapp')}%20data`;
-          req.session.flash_messages.push(`No AWS URL found for environment: ${process.env.ENV}`);
-          res.redirect(`${url_for('base.home')}#${fragment}`);
-        }
+        res.redirect(config.aws.login_url);
       }
     })
     .catch(next);

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -2,6 +2,10 @@ const { Bucket, User } = require('../models');
 const config = require('../config');
 const { url_for } = require('../routes');
 
+if (!config.aws.login_url) {
+  throw new Error('AWS login URL not set');
+}
+
 
 exports.list_buckets = (req, res, next) => {
   Bucket.list()

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -83,11 +83,7 @@ exports.delete = (req, res, next) => {
 exports.aws = (req, res, next) => {
   Bucket.get(req.params.id)
     .then((bucket) => {
-      if (bucket.location_url) {
-        res.redirect(bucket.location_url);
-      } else {
-        res.redirect(config.aws.login_url);
-      }
+      res.redirect(bucket.location_url || config.aws.login_url);
     })
     .catch(next);
 };

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -81,12 +81,8 @@ exports.aws = (req, res, next) => {
       if (bucket.location_url) {
         res.redirect(bucket.location_url);
       } else {
-        const aws_urls = {
-          alpha: 'https://alpha-analytics-moj.eu.auth0.com/samlp/NpfImg4P3ynU6HFx7ivYmqUZWQHfwi3Y',
-          dev: 'https://dev-analytics-moj.eu.auth0.com/samlp/GCTaoFKOc8MjhcfNJym2Fv9aD1YXoewt',
-        };
-        if (aws_urls[process.env.ENV]) {
-          res.redirect(aws_urls[process.env.ENV]);
+        if (config.aws.login_url) {
+          res.redirect(config.aws.login_url);
         } else {
           const fragment = `${(bucket.is_data_warehouse ? 'Warehouse' : 'Webapp')}%20data`;
           req.session.flash_messages.push(`No AWS URL found for environment: ${process.env.ENV}`);

--- a/app/config.js
+++ b/app/config.js
@@ -42,6 +42,10 @@ config.auth0 = {
   sso_logout_url: '/v2/logout',
 };
 
+config.aws = {
+  login_url: process.env.AWS_LOGIN_URL,
+};
+
 config.babel = {
   presets: ['es2015'],
 };

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -74,7 +74,7 @@
                     {% endif %}
                   </td>
                   <td class="align-right no-wrap">
-                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">View data in AWS</a>
+                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open AWS</a>
                   </td>
                 </tr>
               {% endfor %}

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -74,9 +74,7 @@
                     {% endif %}
                   </td>
                   <td class="align-right no-wrap">
-                    {% if aws_url %}
-                      <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open AWS</a>
-                    {% endif %}
+                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open AWS</a>
                   </td>
                 </tr>
               {% endfor %}

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -74,7 +74,9 @@
                     {% endif %}
                   </td>
                   <td class="align-right no-wrap">
-                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open AWS</a>
+                    {% if aws_url %}
+                      <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open AWS</a>
+                    {% endif %}
                   </td>
                 </tr>
               {% endfor %}

--- a/test/conftest.js
+++ b/test/conftest.js
@@ -7,6 +7,10 @@ const nock = require('nock');
 const { load_routes, url_for } = require('../app/routes');
 const { User } = require('../app/models');
 
+// Setting dummy variable to allow tests to pass
+config.aws = {
+  login_url: 'qwertyuiop'
+};
 
 exports.ns = cls.createNamespace(config.continuation_locals.namespace);
 


### PR DESCRIPTION
## What

For the moment, all s3buckets have `location_url` as `null`. This means we can't link to them directly. Working out the URL and manually linking to them skirts round Auth0 and asks for a AWS login. Therefore it was decided just to link to the generic AWS portal page for each environment for now.

## How to review

1. See that buckets listed on "Warehouse data" and "Webapp data" have a button labelled "Open AWS"
2. Check that it opens the AWS page for the env you are on