### PR TITLE
Hide debug panels from non-superusers (on alpha)

### DIFF
--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -153,7 +153,7 @@
 {% endif %}
 
 
-{% if current_user.is_superuser %}
+{% if current_user.is_superuser or env.ENV == 'dev' %}
   <details class="debug">
     <summary>Debug</summary>
 

--- a/app/templates/apps/details.html
+++ b/app/templates/apps/details.html
@@ -153,25 +153,27 @@
 {% endif %}
 
 
-<details class="debug">
-  <summary>Debug</summary>
+{% if current_user.is_superuser %}
+  <details class="debug">
+    <summary>Debug</summary>
 
-  current_user_is_app_admin
-  <h2 class="heading-medium">current_user_is_app_admin</h2>
-  <div>
-    <pre>{{ current_user_is_app_admin }}</pre>
-  </div>
+    current_user_is_app_admin
+    <h2 class="heading-medium">current_user_is_app_admin</h2>
+    <div>
+      <pre>{{ current_user_is_app_admin }}</pre>
+    </div>
 
-  <h2 class="heading-medium">App dump</h2>
-  <div>
-    <pre>{{ app | dump(2) }}</pre>
-  </div>
+    <h2 class="heading-medium">App dump</h2>
+    <div>
+      <pre>{{ app | dump(2) }}</pre>
+    </div>
 
-  <h2 class="heading-medium">Users dump</h2>
-  <div>
-    <pre>{{ users | dump(2) }}</pre>
-  </div>
-</details>
+    <h2 class="heading-medium">Users dump</h2>
+    <div>
+      <pre>{{ users | dump(2) }}</pre>
+    </div>
+  </details>
+{% endif %}
 
 
 {% endblock %}

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -132,7 +132,7 @@
     </section>
   {% endif %}
 
-  {% if current_user.is_superuser %}
+  {% if current_user.is_superuser or env.ENV == 'dev' %}
     <details class="debug">
       <summary>Debug</summary>
       <div class="panel">

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -149,7 +149,7 @@
 {% endif %}
 
 
-{% if current_user.is_superuser %}
+{% if current_user.is_superuser or env.ENV == 'dev' %}
   <details class="debug">
     <summary>Debug</summary>
     <div>

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -149,17 +149,18 @@
 {% endif %}
 
 
-<!-- TODO: Remove me - Dump of available variables -->
-<details class="debug">
-  <summary>Debug</summary>
-  <div>
-    <pre>bucket = {{ bucket | dump(4) | safe }}</pre>
-    <br />
-    <pre>apps_options = {{ apps_options | dump(4) | safe }}</pre>
-    <br />
-    <pre>users_options = {{ users_options | dump(4) | safe }}</pre>
-  </div>
-</details>
+{% if current_user.is_superuser %}
+  <details class="debug">
+    <summary>Debug</summary>
+    <div>
+      <pre>bucket = {{ bucket | dump(4) | safe }}</pre>
+      <br />
+      <pre>apps_options = {{ apps_options | dump(4) | safe }}</pre>
+      <br />
+      <pre>users_options = {{ users_options | dump(4) | safe }}</pre>
+    </div>
+  </details>
+{% endif %}
 
 
 {% endblock %}

--- a/app/templates/errors/internal-error.html
+++ b/app/templates/errors/internal-error.html
@@ -24,6 +24,7 @@
 {{ error.stack | safe }}
 </pre>
 
+
 <details class="debug">
   <summary>Debug</summary>
 

--- a/app/templates/users/details.html
+++ b/app/templates/users/details.html
@@ -13,11 +13,13 @@
 {% include 'users/includes/tables.html' %}
 
 
-<details class="debug">
-  <summary>Debug</summary>
-  <h2 class="heading-medium">User dump</h2>
-  <pre>{{ user | dump(2) }}</pre>
-</details>
+{% if current_user.is_superuser %}
+  <details class="debug">
+    <summary>Debug</summary>
+    <h2 class="heading-medium">User dump</h2>
+    <pre>{{ user | dump(2) }}</pre>
+  </details>
+{% endif %}
 
 
 {% endblock %}

--- a/app/templates/users/details.html
+++ b/app/templates/users/details.html
@@ -13,7 +13,7 @@
 {% include 'users/includes/tables.html' %}
 
 
-{% if current_user.is_superuser %}
+{% if current_user.is_superuser or env.ENV == 'dev' %}
   <details class="debug">
     <summary>Debug</summary>
     <h2 class="heading-medium">User dump</h2>


### PR DESCRIPTION
## What

Makes sure that the debug `<details>` panels are hidden from non-superusers on alpha in case they reveal more than they should (such as access/refresh tokens and the like).

The exception is on the `errors/internal-error.html` template, where it might be handy for users to be able to give us the information shown in the debug panel.

## How to review

1. Log in as a non-superuser
2. Check that debug panels are not visible except on the internal-error template