### PR TITLE
JS error meant that first user in dropdown could not be selected

### DIFF
--- a/app/assets/javascripts/modules/user-typeahead.js
+++ b/app/assets/javascripts/modules/user-typeahead.js
@@ -49,7 +49,7 @@ moj.Modules.userTypeahead = {
     const userText = this.$userTypeahead.val();
     const userIndex = this.users.indexOf(userText);
 
-    if (userIndex > 0) {
+    if (userIndex >= 0) {
       this.selectOption(userIndex + 1);
       this.setFormDisabled(false);
     } else {


### PR DESCRIPTION
## What

Stupid JS mistake meant that the first user in the `<select>` (which is not visible to users, as it is replaced by a JS typeahead) could not be added to a bucket's access group.

[Trello](https://trello.com/c/Wn7layRR/763-cp-bug-grant-access-to-other-users-not-working-in-dev-but-is-in-alpha)