### PR TITLE
Better handling of idled tools

### DIFF
--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const { url_for } = require('../routes');
 
 if (!config.aws.login_url) {
-  throw new Error('AWS login URL not set (set AWS_LOGIN_URL)');
+  throw new Error('AWS_LOGIN_URL must be set');
 }
 
 

--- a/app/buckets/handlers.js
+++ b/app/buckets/handlers.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const { url_for } = require('../routes');
 
 if (!config.aws.login_url) {
-  throw new Error('AWS login URL not set');
+  throw new Error('AWS login URL not set (set AWS_LOGIN_URL)');
 }
 
 

--- a/app/models/kubernetes.js
+++ b/app/models/kubernetes.js
@@ -3,7 +3,7 @@ const config = require('../config');
 const { DoesNotExist } = require('./control_panel_api');
 const cls = require('cls-hooked');
 
-const IDLED_LABEL = 'mojanalytics.xyz/idled';
+const IDLED = 'mojanalytics.xyz/idled';
 
 
 class Model extends base.Model {
@@ -115,7 +115,7 @@ class Deployment extends Model {
   }
 
   get idled() {
-    return this.data.metadata.labels[IDLED_LABEL] === 'true';
+    return this.data.metadata.labels[IDLED] === 'true';
   }
 
   get app_label() {

--- a/app/models/kubernetes.js
+++ b/app/models/kubernetes.js
@@ -3,6 +3,8 @@ const config = require('../config');
 const { DoesNotExist } = require('./control_panel_api');
 const cls = require('cls-hooked');
 
+const IDLED_LABEL = 'mojanalytics.xyz/idled';
+
 
 class Model extends base.Model {
   static get kubernetes() {
@@ -110,6 +112,10 @@ class Deployment extends Model {
 
   get available() {
     return this.data.pods.some(pod => pod.status.phase === 'Running');
+  }
+
+  get idled() {
+    return this.data.metadata.labels[IDLED_LABEL] === 'true';
   }
 
   get app_label() {

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -17,22 +17,22 @@
       <tr>
         <td>{{ tool.app_label }}</td>
         <td>
-          {%- if tool.idled -%}
+          {% if tool.idled %}
             Idled
-          {%- else -%}
-            {% for pod in tool.pods -%}
+          {% else %}
+            {% for pod in tool.pods %}
               {{ loop.index }}. {{ pod.display_status }}<br>
-            {%- endfor %}
-          {%- endif -%}
+            {% endfor %}
+          {% endif %}
         </td>
         <td class="align-right no-wrap">
-          {%- if tool.available -%}
+          {% if tool.available %}
             <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Open</a>
-          {%- elif tool.idled -%}
+          {% elif tool.idled %}
             <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Unidle</a>
-          {%- else -%}
+          {% else %}
             <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
-          {%- endif -%}
+          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -17,15 +17,22 @@
       <tr>
         <td>{{ tool.app_label }}</td>
         <td>
-          {% for pod in tool.pods -%}
-            {{ loop.index }}. {{ pod.display_status }}<br>
-          {%- endfor %}
+          {%- if tool.idled -%}
+            Idled
+          {%- else -%}
+            {% for pod in tool.pods -%}
+              {{ loop.index }}. {{ pod.display_status }}<br>
+            {%- endfor %}
+          {%- endif -%}
         </td>
         <td class="align-right no-wrap">
-          {% if tool.available -%}
+          {%- if tool.available -%}
             <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Open</a>
-          {%- endif %}
-          <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
+          {%- elif tool.idled -%}
+            <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Unidle</a>
+          {%- else -%}
+            <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
+          {%- endif -%}
         </td>
       </tr>
       {% endfor %}

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -28,10 +28,9 @@
         <td class="align-right no-wrap">
           {% if tool.available %}
             <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Open</a>
+            <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
           {% elif tool.idled %}
             <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Unidle</a>
-          {% else %}
-            <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
           {% endif %}
         </td>
       </tr>


### PR DESCRIPTION
### Problem

Tools can now be in an "idled" state (tools are idled overnight to save
resources).

When a tool is idled, its deployment is scaled down so there are no pods
running. This means the CP will not be able to loop through the pods and
show their status.

Another problem is that the "Restart" button is always shown. Users obviously
click on it and expect a tool to wake up from its idled state.

This doesn't work because "Restart" simply delete the pods in a deployment,
causing them to be recreated. When a tool is idled there are zero pods,
so "Restart" is not doing much.

### Changes

- I added the `Deployment.idled` property which checks if a tool is idled.
  This returns true if the deployment has the IDLED='true' label
- In the tools page:
  - in the status column, show "Idled" when a tool is idled
  - show the "Unidle" button when a tool is idled. This opens the tool triggering
    the unidling process as usual
  - don't show the "Restart" button when a tool is idled

### Ticket

https://trello.com/c/am9IhJYr/753-fix-bug-users-cant-recover-from-hibernations-in-the-control-panel

### Also see

- [Idler](https://github.com/ministryofjustice/analytics-platform-idler/blob/master/idler.py#L126)
- [Unidler](https://github.com/ministryofjustice/analytics-platform-unidler/blob/master/unidler.py)