### PR TITLE
Automatically refresh tools status (polling)

### DIFF
--- a/app/assets/javascripts/modules/status-polling.js
+++ b/app/assets/javascripts/modules/status-polling.js
@@ -1,0 +1,30 @@
+moj.Modules.toolsStatusPolling = {
+  toolsSlug: 'Analytical%20tools',
+  pollingFrequency: 10 * 1000,
+  pollingTimer: null,
+
+  init() {
+    this.bindEvents();
+  },
+
+  bindEvents() {
+    moj.Events.on('tab-selected', (event, params) => {
+      if (params.slug === this.toolsSlug) {
+        this.enablePolling();
+      } else {
+        this.disablePolling();
+      }
+    });
+  },
+
+  enablePolling() {
+    this.pollingTimer = setInterval(() => {
+      document.location.reload(true);
+    }, this.pollingFrequency);
+  },
+
+  disablePolling() {
+    clearTimeout(this.pollingTimer);
+  },
+
+};

--- a/app/assets/javascripts/modules/status-polling.js
+++ b/app/assets/javascripts/modules/status-polling.js
@@ -1,4 +1,5 @@
 moj.Modules.toolsStatusPolling = {
+  toolsPath: '/tools',
   toolsSlug: 'Analytical%20tools',
   pollingFrequency: 10 * 1000,
   pollingTimer: null,
@@ -10,21 +11,30 @@ moj.Modules.toolsStatusPolling = {
   bindEvents() {
     moj.Events.on('tab-selected', (event, params) => {
       if (params.slug === this.toolsSlug) {
-        this.enablePolling();
+        this.enablePolling(params.panel);
       } else {
         this.disablePolling();
       }
     });
   },
 
-  enablePolling() {
+  enablePolling(panel) {
     this.pollingTimer = setInterval(() => {
-      document.location.reload(true);
+      this.update(panel);
     }, this.pollingFrequency);
   },
 
   disablePolling() {
-    clearTimeout(this.pollingTimer);
+    clearInterval(this.pollingTimer);
+  },
+
+  update(panel) {
+    $.ajax({
+      url: this.toolsPath,
+      dataType: 'html',
+    }).done((newContent) => {
+      panel.html(newContent);
+    });
   },
 
 };

--- a/app/assets/javascripts/modules/tabs.js
+++ b/app/assets/javascripts/modules/tabs.js
@@ -54,20 +54,20 @@ moj.Modules.tabs = {
   },
 
   showTab(index) {
+    const tab = this.$tabs.eq(index);
+    const panel = this.$panels.eq(index);
+    const slug = this.slugs[index];
+
     this.$tabs.removeClass(this.activeClass);
     this.$panels.removeClass(this.activeClass);
-    this.$tabs.eq(index).addClass(this.activeClass);
-    this.$panels.eq(index).addClass(this.activeClass);
+    tab.addClass(this.activeClass);
+    panel.addClass(this.activeClass);
 
-    document.location.hash = this.slugs[index];
+    document.location.hash = slug;
 
-    this.triggerTabSelected(index);
-  },
-
-  triggerTabSelected(index) {
     moj.Events.trigger('tab-selected', {
-      index,
-      slug: this.slugs[index],
+      slug,
+      panel,
     });
   },
 

--- a/app/assets/javascripts/modules/tabs.js
+++ b/app/assets/javascripts/modules/tabs.js
@@ -60,5 +60,15 @@ moj.Modules.tabs = {
     this.$panels.eq(index).addClass(this.activeClass);
 
     document.location.hash = this.slugs[index];
+
+    this.triggerTabSelected(index);
   },
+
+  triggerTabSelected(index) {
+    moj.Events.trigger('tab-selected', {
+      index,
+      slug: this.slugs[index],
+    });
+  },
+
 };

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -38,6 +38,23 @@ exports.home = (req, res, next) => {
     .catch(next);
 };
 
+exports.tools = (req, res, next) => {
+  const { rstudio_is_deploying } = req.session;
+  const ns = cls.getNamespace(config.continuation_locals.namespace);
+  req.session.rstudio_is_deploying = false;
+
+  Deployment.list()
+    .then((tools) => {
+      ns.run(() => {
+        res.render('tools/includes/list.html', {
+          tools,
+          rstudio_is_deploying,
+        });
+      });
+    })
+    .catch(next);
+};
+
 
 exports.whats_new = (req, res, next) => {
   request(config.whats_new.url)

--- a/app/base/routes.js
+++ b/app/base/routes.js
@@ -3,6 +3,7 @@ const handlers = require('./handlers');
 
 module.exports = [
   { name: 'home', pattern: '/', handler: handlers.home },
+  { name: 'tools', pattern: '/tools', handler: handlers.tools },
   { name: 'whats-new', pattern: '/whats-new', handler: handlers.whats_new },
   { name: 'callback', pattern: '/callback', handler: handlers.auth_callback },
   { name: 'login', pattern: '/login', handler: handlers.login },

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -31,8 +31,6 @@
   {% endif %}
 
   <section class="tab-panel">
-    <h2 class="heading-medium">Your tools</h2>
-
     {% include 'tools/includes/list.html' %}
   </section>
 

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -1,6 +1,8 @@
 {% block main_column %}
 
-<p>Please refresh your browser to update the status of your tools.</p>
+<h2 class="heading-medium">Your tools</h2>
+
+<p>The status of your tools will update automatically.</p>
 
 <table class="form-group list">
   <thead>


### PR DESCRIPTION
### What

When the user is on the Tools tab, this panel content is updated every
few seconds (10 seconds) with the response from the `GET /tools` endpoint.

This `GET /tools` endpoint renders only the panel content (same template
used by the `home` template) but it's lighter as it only requests the tools
status.

**NOTE**: The polling is enabled only when the user selected the "Tools" tab and disabled when it's on other tabs so we don't make unnecessary requests.

### Why
Some users were expecting the tools status to refresh automatically and were confused by the fact the status didn't change.

### Technical details
The logic is in the `status-polling` module. The `tabs` module now emit a `tab-selected` event when a tab is selected, this event also contains the slug and the panel selected.

The `status-polling` module handle these events and enable/disable the polling accordingly (using `(set|clear)Interval`). Every 10 seconds the page makes an AJAX request to `GET /tools` and update the panel content with the new content from the response of this request.

### How to review

1. Go to the "Tools" tab
2. Deploy/Restart your RStudio
3. Wait ~10s and see the status change
4. Profit!


### Ticket

https://trello.com/c/2A3FU0uJ/787-4-polling-tools-status-in-cp