### PR TITLE
Grafana link

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -26,12 +26,14 @@ exports.home = (req, res, next) => {
           groupedBuckets[group].push(bucket);
           return groupedBuckets;
         }, {});
+        const grafana_url = encodeURI(`${config.grafana.dashboard_url}&var-Username=${user.username}`);
 
         res.render('base/home.html', {
           tools,
           rstudio_is_deploying,
           user,
           buckets,
+          grafana_url,
         });
       });
     })

--- a/app/config.js
+++ b/app/config.js
@@ -88,6 +88,10 @@ config.express = {
   host: process.env.EXPRESS_HOST || '127.0.0.1',
 };
 
+config.grafana = {
+  dashboard_url: `https://grafana.services.${process.env.ENV}.mojanalytics.xyz/d/000000002/platform-users?refresh=10s&orgId=1`,
+};
+
 config.js = {
   sourceFiles: join(__dirname, 'assets/javascripts/**/*.js'),
   ignorePaths: [

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -58,7 +58,11 @@
   </table>
 
   <p>
-    You can <a href="https://grafana.services.alpha.mojanalytics.xyz/d/000000002/platform-users?refresh=10s&amp;orgId=1&amp;var-Username={{ current_user.username }}" target="_blank">view your resource utilisation on Grafana (opens in new tab)</a>.
+    {% if env.ENV == 'alpha' %}
+      You can <a href="{{ grafana_url }}" target="_blank">view your resource utilisation on Grafana (opens in new tab)</a>.
+    {% else %}
+      <em>(Grafana not available on environment: {{ env.ENV }})</em>
+    {% endif %}
   </p>
 
 {% endblock %}

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -57,4 +57,8 @@
     </tbody>
   </table>
 
+  <p>
+    You can <a href="https://grafana.services.alpha.mojanalytics.xyz/d/000000002/platform-users?refresh=10s&amp;orgId=1&amp;var-Username={{ current_user.username }}" target="_blank">view your resource utilisation on Grafana (opens in new tab)</a>.
+  </p>
+
 {% endblock %}


### PR DESCRIPTION
## What

Simply puts a link (with `target="_blank"` so it opens in a new window) to Grafana on the tools page. The user's username is embedded in the link and Grafana has been tweaked to just show the time series (RAM and CPU) for that user.

## How to review

1. Check out and see the link on your tools page
2. Give it a gentle click, do not frighten it
3. See your CPU/RAM usage on Grafana in time series form and also in comparative bar graph form for context

Note, we only have Grafana on ALPHA env, so other envs show alternate text.