### PR TITLE
Redirect users to /login when "state mismatch" errors occur

### DIFF
--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -3,7 +3,6 @@ const config = require('../config');
 const cls = require('cls-hooked');
 const passport = require('passport');
 const { url_for } = require('../routes');
-const uuid = require('uuid');
 const request = require('request-promise');
 
 
@@ -95,7 +94,6 @@ exports.login = (req, res, next) => {
     }
   } else {
     passport.authenticate('oidc', {
-      state: uuid(),
       prompt: req.query.prompt || 'none',
     })(req, res, next);
   }

--- a/app/middleware/errors.js
+++ b/app/middleware/errors.js
@@ -2,14 +2,14 @@ const sentry = require('raven');
 const errlog = require('bole')('error-handler');
 
 
-const handle_state_mismatch = (req, res, conf) => {
+function handle_state_mismatch(req, res, conf) {
   errlog.info('Handling "state mismatch" error by redirecting user to login page...');
 
   req.session.destroy(() => {
     res.clearCookie(conf.session.name);
     res.redirect('/login');
   });
-};
+}
 
 module.exports = (app, conf, log) => {
   log.info('adding errors');

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "request-promise": "^4.2.1",
     "request-promise-core": "^1.1.1",
     "selenium-standalone": "^6.14.1",
-    "uuid": "^3.2.1",
     "webdriverio": "^4.12.0"
   },
   "devDependencies": {

--- a/test/middleware/test-errors.js
+++ b/test/middleware/test-errors.js
@@ -1,0 +1,43 @@
+const { assert } = require('chai');
+const app = require('express')();
+const config = require('../../app/config');
+const log = require('bole')('middleware');
+const errors_middleware = require('../../app/middleware/errors')(app, config, log);
+
+
+describe('When a "state mismatch" error occurs', () => {
+  it('redirects the user to /login', () => {
+    let spy_session_destroyed = false;
+    let spy_cookie_cleared = 'NOT CLEARED';
+    let spy_redirected_to = 'NOT REDIRECTED';
+    let spy_next_called = false;
+
+    const err = Error('state mismatch, could not find [...]');
+    const req = {
+      session: {
+        destroy: (after_destroy) => {
+          spy_session_destroyed = true;
+          after_destroy();
+        },
+      },
+    };
+    const res = {
+      clearCookie: (name) => {
+        spy_cookie_cleared = name;
+      },
+      redirect: (url) => {
+        spy_redirected_to = url;
+      },
+    };
+    const next = () => {
+      spy_next_called = true;
+    };
+
+    errors_middleware(err, req, res, next)
+
+    assert.isTrue(spy_session_destroyed);
+    assert.equal(spy_cookie_cleared, config.session.name);
+    assert.equal(spy_redirected_to, '/login');
+    assert.isFalse(spy_next_called, 'next() called');
+  });
+});


### PR DESCRIPTION
### What
Users sometimes see these errors. We're now handling them more gracefully by:
* Clearing their session
* Clearing their session cookie and 
* redirecting the user to `/login`

(they'll need to login again if they're not logged in the "central" SSO)

### How to review

1. Start the app
2. Log in
3. Go to [http://localhost:3000/callback?code=BROKEN&state=BROKEN](http://localhost:3000/callback?code=BROKEN&state=BROKEN)
4. Check the logs for `info error-handler: Handling "state mismatch" error by redirecting user to login page...`
5. You should be redirected back to `/login`/logged in

### Ticket
https://trello.com/c/5czelJkJ/797-fix-internal-error-state-mismatch-error

### About `state`
[Auth0 documentation on `state` param](https://auth0.com/docs/protocols/oauth2/oauth-state)

### Also
I also removed the (direct) dependency to `uuid` as we don't need to generate the `state` value explicitly.
