### PR TITLE
Re-enable docker image build and push to Quay.io

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,53 @@ jobs:
             - node_modules
             - static
 
+  docker_build_and_push:
+    docker:
+      - image: docker:17.06.0-ce-git
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
+      - restore_cache:
+          keys:
+            - image-cache-{{ .Branch }}
+            - image-cache-
+          paths:
+            - /caches/app.tar
+      - run:
+          name: Load Docker image layer cache
+          command: |
+            set +o pipefail
+            docker load -i /caches/app.tar | true
+      - run:
+          name: Build application Docker image
+          command: docker build --cache-from=app -t app .
+      - run:
+          name: Save Docker image layer cache
+          command: |
+            mkdir -p /caches
+            docker save -o /caches/app.tar app
+      - save_cache:
+          key: image-cache-{{ .Branch }}
+          paths:
+            - /caches/app.tar
+      - run:
+          name: Push Docker image to Quay Container Registry
+          environment:
+            IMAGE: quay.io/mojanalytics/control-panel-frontend
+          command: |
+            docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} quay.io
+            docker tag app "${IMAGE}:${CIRCLE_SHA1}"
+            docker tag app "${IMAGE}:${CIRCLE_BRANCH}"
+            docker push "${IMAGE}:${CIRCLE_SHA1}"
+            docker push "${IMAGE}:${CIRCLE_BRANCH}"
+
 workflows:
   version: 2
-  test:
+  test-build-and-push-docker-image:
     jobs:
       - build_and_test
+      - docker_build_and_push:
+          requires:
+            - build_and_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,9 @@ jobs:
             docker tag app "${IMAGE}:${CIRCLE_SHA1}"
             docker tag app "${IMAGE}:${CIRCLE_BRANCH}"
             docker push "${IMAGE}:${CIRCLE_SHA1}"
+            echo "Pushed Docker image to ${IMAGE}:${CIRCLE_SHA1}"
             docker push "${IMAGE}:${CIRCLE_BRANCH}"
+            echo "Pushed Docker image to ${IMAGE}:${CIRCLE_BRANCH}"
 
 workflows:
   version: 2


### PR DESCRIPTION
### What
It was [~accidentally~ disabled here (see reason below)](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/pull/172/files) so images for new commits are not built/pushed to Quay.io.

I mostly copied from that commit with a couple of exceptions:
- We still don't want to push to Jenkins (which is now dead)
- Hence, we don't need to install curl, used to submit the Jenkins job
- Added the `IMAGE` environment variable to improve readability and reduce
  duplication
- Renamed step `deploy` to `docker_build_and_push`
- Use `run` step instead of `deploy` to better express intent and avoid
  confusion
- Renamed workflow from `test` to `test-build-and-push-docker-image` to
  be more explicit

### Why Docker build/push was disabled
The reason why @andyhd disabled the docker build/push was because we're replacing Jenkins with Concourse. The Concourse pipeline will be responsible for the Docker build/push to Quay.io.

### How to review

1. Check the CircleCI logs
2. Do you spot anything wrong?
3. Is the new Docker image available in [quay.io](https://quay.io/repository/mojanalytics/control-panel-frontend?tab=tags)


### Ticket
This problem just popped out, should I create a ticket?