### PR TITLE
Force page size zero

### DIFF
--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -44,7 +44,7 @@ class Model extends base.Model {
   }
 
   static list() {
-    return this.cpanel.get(this.endpoint)
+    return this.cpanel.get(this.endpoint, { page_size: 0 })
       .then(result => new ModelSet(this.prototype.constructor, result.results));
   }
 

--- a/test/apps/test-create.js
+++ b/test/apps/test-create.js
@@ -58,7 +58,7 @@ describe('apps/create', () => {
     });
 
     mock_api()
-      .get('/s3buckets/')
+      .get('/s3buckets/?page_size=0')
       .reply(200, []);
 
     return dispatch(handlers.create, { body: form_data })

--- a/test/apps/test-edit.js
+++ b/test/apps/test-edit.js
@@ -13,8 +13,8 @@ describe('apps/edit', () => {
   it('loads app, buckets and users and shows a form', () => {
     mock_api().get(`/apps/${app.id}/`).reply(200, app);
     mock_api().get(`/apps/${app.id}/customers/`).reply(200, customers);
-    mock_api().get('/s3buckets/').reply(200, buckets);
-    mock_api().get('/users/').reply(200, users);
+    mock_api().get('/s3buckets/?page_size=0').reply(200, buckets);
+    mock_api().get('/users/?page_size=0').reply(200, users);
 
     const expected = {
       app: new App(app),

--- a/test/buckets/test-details.js
+++ b/test/buckets/test-details.js
@@ -16,8 +16,8 @@ describe('buckets/details', () => {
 
     mock_api().get(`/s3buckets/${bucket.id}/`).reply(200, bucket);
     mock_api().get(`/s3buckets/${bucket.id}/access_logs/`).reply(200, access_logs);
-    mock_api().get('/apps/').reply(200, apps);
-    mock_api().get('/users/').reply(200, users);
+    mock_api().get('/apps/?page_size=0').reply(200, apps);
+    mock_api().get('/users/?page_size=0').reply(200, users);
 
     const expected = {
       apps: new ModelSet(App, apps.results).slice(1),

--- a/test/users/test-edit.js
+++ b/test/users/test-edit.js
@@ -12,8 +12,8 @@ describe('users', () => {
   describe('edit', () => {
     it('loads user, apps and buckets and shows a form', () => {
       mock_api().get(`/users/${escape(user.auth0_id)}/`).reply(200, user);
-      mock_api().get('/apps/').reply(200, apps);
-      mock_api().get('/s3buckets/').reply(200, buckets);
+      mock_api().get('/apps/?page_size=0').reply(200, apps);
+      mock_api().get('/s3buckets/?page_size=0').reply(200, buckets);
 
       const expected = {
         user: new User(user),


### PR DESCRIPTION
## What

Adds `?page_size=0` to all API requests to `list` anything in order to work around the "100 users only" bug. Setting `page_size` to 0 means return all records.

## How to review

1. You're unlikely to have more than 100 of anything in local dev, but you can create for example 10 users, then
2. edit L47 of `models/control_panel_api.js` to say `page_size: 3`
3. then list all users, and you should only see 3
4. change it back to `page_size: 0` and you should see all your users

Note: This should be replaced in future with proper pagination, using a non-zero `page_size` and writing out pagination buttons.