### PR TITLE
open AWS in new window, add rel noopener on new window links

### DIFF
--- a/app/assets/javascripts/modules/new-tabs.js
+++ b/app/assets/javascripts/modules/new-tabs.js
@@ -1,0 +1,20 @@
+moj.Modules.newTabs = {
+  init() {
+    this.$newWindowLinks = $('a[target="_blank"]');
+
+    if (this.$newWindowLinks.length) {
+      this.addNewWindowTitleText();
+    }
+  },
+
+  addNewWindowTitleText() {
+    this.$newWindowLinks.each((n, link) => {
+      let titleText = $(link).attr('title') || '';
+      if (titleText.length) {
+        titleText += ' ';
+      }
+      titleText += '(opens in a new tab/window)';
+      $(link).attr('title', titleText);
+    });
+  },
+};

--- a/app/templates/base/home.html
+++ b/app/templates/base/home.html
@@ -70,7 +70,7 @@
                     {% endif %}
                   </td>
                   <td class="align-right no-wrap">
-                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}">Open on AWS</a>
+                    <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: users3bucket.s3bucket.id }) }}" target="_blank" rel="noopener">Open on AWS</a>
                   </td>
                 </tr>
               {% endfor %}

--- a/app/templates/buckets/details.html
+++ b/app/templates/buckets/details.html
@@ -13,7 +13,7 @@
 {% block main_column %}
 
 <div class="form-group">
-  <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: bucket.id }) }}">Open on AWS</a>
+  <a class="button button-secondary" href="{{ url_for('buckets.aws', { id: bucket.id }) }}" target="_blank" rel="noopener">Open on AWS</a>
 </div>
 
 <h2 class="heading-medium">Data access group</h2>

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -29,10 +29,10 @@
         </td>
         <td class="align-right no-wrap">
           {% if tool.available %}
-            <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Open</a>
+            <a class="button button-secondary" target="_blank" rel="noopener" href="{{ tool.url }}">Open</a>
             <a class="button button-secondary" href="{{ url_for('tools.restart', { name: tool.metadata.name }) }}">Restart</a>
           {% elif tool.idled %}
-            <a class="button button-secondary" target="_blank" href="{{ tool.url }}">Unidle</a>
+            <a class="button button-secondary" target="_blank" rel="noopener" href="{{ tool.url }}">Unidle</a>
           {% endif %}
         </td>
       </tr>
@@ -59,7 +59,7 @@
 
   <p>
     {% if env.ENV == 'alpha' %}
-      You can <a href="{{ grafana_url }}" target="_blank">view your resource utilisation on Grafana (opens in new tab)</a>.
+      You can <a href="{{ grafana_url }}" target="_blank" rel="noopener">view your resource utilisation on Grafana (opens in new tab)</a>.
     {% else %}
       <em>(Grafana not available on environment: {{ env.ENV }})</em>
     {% endif %}


### PR DESCRIPTION
## What

Links to open buckets on AWS should open a new tab/window so that people don't lose what they were doing.

Also I've added `rel="noopener"` to all links that open with `target="_blank"` as there can be a security risk with that. It's unlikely to be an issue, but it's still a best practice and I forgot before.

Finally I've added a little JS to add "(opens in a new tab/window)" to the `title` attribute for these links, because accessibility.

## How to review

1. create a bucket if need be, then visit its details page
2. click "Open on AWS"
3. be dazzled by the advanced new-tab-opening technology in play