### PR TITLE
Rstudio deployment obscured by another deployment

### DIFF
--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -37,7 +37,17 @@
         </td>
       </tr>
       {% endfor %}
-    {% else %}
+    {% endif %}
+
+    {% set showRstudio = true %}
+    {% for tool in tools %}
+      {% if tool.name == 'rstudio' %}
+        {% set showRstudio = false %}
+      {% endif %}
+    {% endfor %}
+    {% if showRstudio %}
+
+    <tr>
       <td>RStudio</td>
       <td>
         {% if rstudio_is_deploying %}
@@ -53,6 +63,8 @@
           </form>
         {% endif %}
       </td>
+    </tr>
+
     {% endif %}
     </tbody>
   </table>


### PR DESCRIPTION
See: [Trello Issue](https://trello.com/c/kL1TJGu6)

## What

Edge case:
When a k8s deployment is present in a given namespace (regardless of what app it is) the
logic on the list template's `if` expression will always evaluate to __true__
and never go into the `else` block where we've placed the controls to
manage __rstudio__.
So for example if there is a k8s deployment present that is **not** __rstudio__ and an __rstudio__ k8s deployment has not been created yet?
The user has no way of launcing/deploying __rstudio__.

Workaround:

- Change logic by remove `else` block ending the `if`

- Set a bool variable to gate __Rstudio__ controls

- Loop through __tools__ list and check if __Rstudio__ is present

- `if` not present display __Rstudio__ Deploy context control

The map shows which tools are managed by the Control-Panel (Just __rstudio__ at the moment)

## How to review

#### Before my change

1. Use the `docker-compose` environment as instructed [here](https://github.com/ministryofjustice/analytics-platform-control-panel-frontend/blob/master/README.md)
2. Ensure you do not have a k8s __rstudio__ deployment present in your workspace
- `helm ls <YOUR GITHUBUSERNAME>`
- `helm del --purge <YOUR GITHUBUSERNAME>-rstudio`
3. If not deployed already? Deploy the Jupyter chart into your namespace
- `helm install analytics-platform-helm-charts/charts/jupyter-lab --name jupyter-lab-<YOUR GITHUBUSERNAME> --set Username=<YOUR GITHUBUSERNAME> --set aws.iamRole=alpha_user_<YOUR GITHUBUSERNAME> --namespace=user-<YOUR GITHUBUSERNAME> -f analytics-platform-config/chart-env-config/dev/jupyter.yml`
4. Browse to the Control-Panel Frontend. There you should see something similar to:
![ScreenShot](https://trello-attachments.s3.amazonaws.com/58fa09c54dde6beeffc69175/5acdc52c9fe6620cf43b84f8/2a3b382358779340ef82c54d026ffd57/Screen_Shot_2018-04-11_at_09.25.24.png)

#### After my change

Same as above except you should be able to **Deploy** __rstudio__ 
