### PR TITLE
One Deployment Obscures Another Fix

### DIFF
--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -41,7 +41,7 @@
 
     {% set showRstudio = true %}
     {% for tool in tools %}
-      {% if tool.name == 'rstudio' %}
+      {% if tool.app_label == 'rstudio' %}
         {% set showRstudio = false %}
       {% endif %}
     {% endfor %}


### PR DESCRIPTION
We want to evaluate the label => `app` from the k8s deployment.

This is referenced by the `app_label` property.
