### PR TITLE
Upgrade eslint-airbnb plugin and fix stuff accordingly

### DIFF
--- a/app/api_clients/base.js
+++ b/app/api_clients/base.js
@@ -58,9 +58,7 @@ class APIClient {
       };
       log.debug(`${method} ${options.uri}`);
       return request(options)
-        .then(result =>
-          // console.dir(result);
-          result)
+        .then(result => result)
         .catch((error) => {
           log.error(`${method} ${options.uri} ${error.statusCode || 'errored'}`);
           log.error(`Query: ${JSON.stringify(params, null, 2)}`);

--- a/app/api_clients/control_panel_api.js
+++ b/app/api_clients/control_panel_api.js
@@ -1,6 +1,6 @@
-const { APIClient, APIError } = require('./base');
 const log = require('bole')('control_panel_api');
 const passport = require('passport');
+const { APIClient, APIError } = require('./base');
 
 
 class ControlPanelAPIClient extends APIClient {

--- a/app/api_clients/kubernetes.js
+++ b/app/api_clients/kubernetes.js
@@ -1,5 +1,5 @@
-const { ControlPanelAPIClient } = require('./control_panel_api');
 const url = require('url');
+const { ControlPanelAPIClient } = require('./control_panel_api');
 
 
 function get_namespace(username) {

--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -1,6 +1,6 @@
+const cls = require('cls-hooked');
 const { App, Bucket, User } = require('../models');
 const { Repo } = require('../models/github');
-const cls = require('cls-hooked');
 const config = require('../config');
 const { GithubAPIClient } = require('../api_clients/github');
 const { url_for } = require('../routes');

--- a/app/assets.js
+++ b/app/assets.js
@@ -6,8 +6,8 @@ const concatfiles = require('concat-files');
 const path = require('path');
 const babel = require('babel-core');
 
-const config = require('./config');
 const log = require('bole')('assets');
+const config = require('./config');
 
 
 function relative(filepath) {

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -1,9 +1,9 @@
-const { Deployment, User } = require('../models');
-const config = require('../config');
 const cls = require('cls-hooked');
 const passport = require('passport');
-const { url_for } = require('../routes');
 const request = require('request-promise');
+const config = require('../config');
+const { Deployment, User } = require('../models');
+const { url_for } = require('../routes');
 
 
 function sso_logout_url() {

--- a/app/factory.js
+++ b/app/factory.js
@@ -1,10 +1,10 @@
-const config = require('./config');
 const express = require('express');
 const { join } = require('path');
 const log = require('bole')('middleware');
 const nunjucks = require('nunjucks');
 const markdown = require('nunjucks-markdown');
 const marked = require('marked');
+const config = require('./config');
 
 
 function init_app(app, conf) {

--- a/app/middleware/api.js
+++ b/app/middleware/api.js
@@ -1,6 +1,6 @@
+const cls = require('cls-hooked');
 const { ControlPanelAPIClient } = require('../api_clients/control_panel_api');
 const { KubernetesAPIClient } = require('../api_clients/kubernetes');
-const cls = require('cls-hooked');
 
 
 module.exports = (app, conf, log) => {

--- a/app/middleware/authentication.js
+++ b/app/middleware/authentication.js
@@ -1,8 +1,8 @@
-const config = require('../config');
 const passport = require('passport');
-const { User } = require('../models');
 const { Issuer, Strategy } = require('openid-client');
 const auth_log = require('bole')('authentication middleware');
+const { User } = require('../models');
+const config = require('../config');
 
 
 let client = null;

--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -1,6 +1,6 @@
+const cls = require('cls-hooked');
 const { APIError } = require('../api_clients/base');
 const base = require('./base');
-const cls = require('cls-hooked');
 const config = require('../config');
 const { get_namespace } = require('../api_clients/kubernetes');
 

--- a/app/models/kubernetes.js
+++ b/app/models/kubernetes.js
@@ -1,7 +1,7 @@
+const cls = require('cls-hooked');
 const base = require('./base');
 const config = require('../config');
 const { DoesNotExist } = require('./control_panel_api');
-const cls = require('cls-hooked');
 
 const IDLED = 'mojanalytics.xyz/idled';
 

--- a/app/server.js
+++ b/app/server.js
@@ -1,8 +1,8 @@
+const log = require('bole')('server');
+
 const app = require('./index');
 const assets = require('./assets');
 const config = require('./config').express;
-
-const log = require('bole')('server');
 
 
 log.info('Server process starting');

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "chai": "^4.1.2",
     "chai-spies": "^1.0.0",
     "eslint": "^5.0.1",
-    "eslint-config-airbnb-base": "12.1.0",
+    "eslint-config-airbnb-base": "^13.0.0",
     "eslint-plugin-import": "^2.13.0",
     "mocha": "^5.2.0",
     "nock": "^9.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1715,7 +1715,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.10.0:
+es-abstract@^1.10.0, es-abstract@^1.6.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
@@ -1762,11 +1762,13 @@ escodegen@1.x.x:
   optionalDependencies:
     source-map "~0.5.6"
 
-eslint-config-airbnb-base@12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz#386441e54a12ccd957b0a92564a4bafebd747944"
+eslint-config-airbnb-base@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-13.0.0.tgz#2ee6279c4891128e49d6445b24aa13c2d1a21450"
   dependencies:
     eslint-restricted-globals "^0.1.1"
+    object.assign "^4.1.0"
+    object.entries "^1.0.4"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
@@ -2282,7 +2284,7 @@ ftp@~0.3.10:
     readable-stream "1.1.x"
     xregexp "2.0.0"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -2595,10 +2597,10 @@ has-values@^1.0.0:
     kind-of "^4.0.0"
 
 has@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
   dependencies:
-    function-bind "^1.0.2"
+    function-bind "^1.1.1"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -3965,8 +3967,8 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-keys@^1.0.11, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -3974,7 +3976,7 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.0.4:
+object.assign@^4.0.4, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -3982,6 +3984,15 @@ object.assign@^4.0.4:
     function-bind "^1.1.1"
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.omit@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## What

When upgrading some ESLint related dependencies, much stuff appeared to break. On further investigation it appears that the AirBNB ruleset we use has either added a rule or made one more strict, to do with the order of imported packages/objects. These have been fixed accordingly.

Mildly annoyingly, the latest version of `eslint-config-airbnb-base` has a peer dependency on an older version of `eslint` and so throws a warning. It's just a warning though, and everything works as it should.