### PR TITLE
Upgrade github package to octokit/rest

### DIFF
--- a/app/apps/handlers.js
+++ b/app/apps/handlers.js
@@ -14,7 +14,6 @@ exports.new = (req, res, next) => {
     .then(() => Promise.all([Repo.list(), Bucket.list()]))
     .then(([repos, buckets]) => {
       res.render('apps/new.html', {
-        repo_prefix: config.github.web_host,
         orgs: config.github.orgs,
         repos,
         bucket_prefix: `${process.env.ENV}-`,

--- a/app/config.js
+++ b/app/config.js
@@ -149,8 +149,6 @@ config.middleware = [
 ];
 
 config.github = {
-  host: 'api.github.com',
-  web_host: 'https://github.com',
   orgs: [
     'moj-analytical-services',
     'ministryofjustice',

--- a/app/templates/apps/new.html
+++ b/app/templates/apps/new.html
@@ -20,8 +20,7 @@
         <span class="error-message">{{ error }}</span>
       {% endfor %}
     {% endif %}
-    <input type="hidden" name="repo_prefix" id="repo_prefix" value="{{ repo_prefix }}">
-    <label for="name" class="form-control-prefix">{{ repo_prefix }}</label>
+    <label for="name" class="form-control-prefix">https://github.com</label>
     <span>/</span>
     <select name="repo_org" id="repo_org" class="form-control form-control-1-3">
       {% for org in orgs %}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/ministryofjustice/analytics-platform-control-panel-frontend#readme",
   "dependencies": {
+    "@octokit/rest": "^15.9.3",
     "auth0": "^2.10.0",
     "authenticator-cli": "^1.0.5",
     "babel-core": "^6.26.3",
@@ -37,7 +38,6 @@
     "dotenv": "^6.0.0",
     "express": "4.16.3",
     "express-session": "^1.15.6",
-    "github": "^13.0.1",
     "glob": "^7.1.2",
     "govuk-elements-sass": "3.1.2",
     "govuk_frontend_toolkit": "7.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@octokit/rest@^15.9.3":
+  version "15.9.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-15.9.3.tgz#1177ccdfad29f7073756c98afc0890347e21788f"
+  dependencies:
+    before-after-hook "^1.1.0"
+    btoa-lite "^1.0.0"
+    debug "^3.1.0"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.0"
+    lodash "^4.17.4"
+    node-fetch "^2.1.1"
+    url-template "^2.0.8"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
@@ -37,6 +50,12 @@ agent-base@2, agent-base@^2.1.1:
   dependencies:
     extend "~3.0.0"
     semver "~5.0.1"
+
+agent-base@4:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 agent-base@^4.1.0:
   version "4.1.2"
@@ -794,6 +813,10 @@ becke-ch--regex--s0-0-v1--base--pl--lib@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.4.0.tgz#429ceebbfa5f7e936e78d73fbdc7da7162b20e20"
 
+before-after-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.1.0.tgz#83165e15a59460d13702cb8febd6a1807896db5a"
+
 binary-extensions@^1.0.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
@@ -924,6 +947,10 @@ browser-stdout@1.3.0:
 browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
 
 buffer-alloc-unsafe@^0.1.0:
   version "0.1.1"
@@ -1655,10 +1682,6 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
-dotenv@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
-
 dotenv@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.0.0.tgz#24e37c041741c5f4b25324958ebbc34bca965935"
@@ -2362,17 +2385,6 @@ gherkin@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/gherkin/-/gherkin-5.1.0.tgz#684bbb03add24eaf7bdf544f58033eb28fb3c6d5"
 
-github@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/github/-/github-13.0.1.tgz#4ccf4a41df662f92367e77a474674eabb1b6c78d"
-  dependencies:
-    debug "^3.1.0"
-    dotenv "^4.0.0"
-    https-proxy-agent "^2.1.0"
-    lodash "^4.17.4"
-    proxy-from-env "^1.0.0"
-    url-template "^2.0.8"
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -2660,6 +2672,13 @@ http-proxy-agent@1, http-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
+http-proxy-agent@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
+  dependencies:
+    agent-base "4"
+    debug "3.1.0"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -2684,9 +2703,9 @@ https-proxy-agent@1, https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-https-proxy-agent@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz#a7ce4382a1ba8266ee848578778122d491260fd9"
+https-proxy-agent@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
@@ -3744,6 +3763,10 @@ nock@^9.3.3:
     qs "^6.5.1"
     semver "^5.5.0"
 
+node-fetch@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+
 node-forge@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.1.tgz#9da611ea08982f4b94206b3beb4cc9665f20c300"
@@ -4400,10 +4423,6 @@ proxy-agent@2:
     lru-cache "~2.6.5"
     pac-proxy-agent "^2.0.0"
     socks-proxy-agent "2"
-
-proxy-from-env@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
 
 ps-tree@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Upgrade github package to octokit/rest

This couldn't happen automatically because of the way we were constructing the
proxy object for the github API.

The old version of the API returned an object that took a config and could be
`extended`, the new version of the api dynamically constructs the rest client by
going through it's own list of plugins and attaching methods to itself. This
didn't play well with the es6 extends syntax and after the version bump the
`authenticate` method we overrode was still pointing to the library version.

I've changed to shadowing it in the constructor instead of overriding it. This
seems to work.

resolves #178

https://trello.com/c/2jHQX3Gu/894-upgrade-github-dependency-to-octokit-rest


1. go to the apps/new endpoint
2. try to search for a github repo in the input box
3. the dropdown should have github repos