### PR TITLE
Fix missing 'app' key in apps3bucket update

### DIFF
--- a/app/apps3buckets/handlers.js
+++ b/app/apps3buckets/handlers.js
@@ -16,11 +16,11 @@ exports.create = (req, res, next) => {
 exports.update = (req, res, next) => {
   const { access_level, redirect_to } = req.body;
 
-  new AppS3Bucket({
-    id: req.params.id,
-    access_level,
-  })
-    .update()
+  AppS3Bucket.get(req.params.id)
+    .then((bucket) => {
+      bucket.access_level = access_level;
+      return bucket.update();
+    })
     .then(() => {
       res.redirect(redirect_to);
     })

--- a/test/apps3buckets/test-update.js
+++ b/test/apps3buckets/test-update.js
@@ -5,22 +5,33 @@ const handlers = require('../../app/apps3buckets/handlers');
 
 describe('apps3buckets.update', () => {
   it('patches the specified apps3bucket', () => {
-    const apps3bucket_id = 42;
+    const apps3bucket = {
+      id: 42,
+      app_id: 1,
+      s3bucket_id: 1,
+      access_level: 'readwrite'
+    };
     const access_level = 'readonly';
     const redirect_to = 'apps/123';
 
+    const get_apps3bucket = mock_api()
+      .get(`/apps3buckets/${apps3bucket.id}/`)
+      .reply(200, apps3bucket);
     const patch_apps3buckets = mock_api()
-      .patch(`/apps3buckets/${apps3bucket_id}/`, {
-        id: apps3bucket_id,
+      .patch(`/apps3buckets/${apps3bucket.id}/`, {
+        id: apps3bucket.id,
+        app_id: apps3bucket.app_id,
+        s3bucket_id: apps3bucket.s3bucket_id,
         access_level,
       })
       .reply(201);
 
-    const params = { id: apps3bucket_id };
+    const params = { id: apps3bucket.id };
     const body = { access_level, redirect_to };
 
     return dispatch(handlers.update, { params, body })
       .then(({ redirect_url }) => {
+        assert(get_apps3bucket.isDone());
         assert(patch_apps3buckets.isDone());
         assert.equal(redirect_url, redirect_to);
       });


### PR DESCRIPTION
## What

* Fetch the AppS3Bucket before updating it, because the API requires the `app_id` and `s3bucket_id` parameters to be passed, not just the `access_level` we want to patch.

## How to review

1. Browse to an app with an attached bucket
2. Click the button to make the attached bucket read-only or read-write
3. See that you don't get a 500 error and the attached bucket access level is changed

See [Trello #1105](https://trello.com/c/dbH5yOGd)