### PR TITLE
Update grafana dashboard URL

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -109,7 +109,7 @@ config.express = {
 };
 
 config.grafana = {
-  dashboard_url: `https://grafana.services.${process.env.ENV}.mojanalytics.xyz/d/000000002/platform-users?refresh=10s&orgId=1`,
+  dashboard_url: `https://grafana.services.${process.env.ENV}.mojanalytics.xyz/d/platformusers/platform-users?refresh=10s&orgId=1`,
 };
 
 config.js = {


### PR DESCRIPTION
The Grafana dashboard URL has changed, because it generates an internal id as part of the URL by default - that has been changed to use a static value. See matching PR in [`analytics-platform-config`](https://github.com/ministryofjustice/analytics-platform-config/pull/92).
