### PR TITLE
Support for deploying JupyterLab

### DIFF
--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -278,3 +278,15 @@ class UserApp extends Model {
 }
 
 exports.UserApp = UserApp;
+
+class Tool extends Model {
+  static get endpoint() {
+    return 'tools';
+  }
+
+  static get pk() {
+    return 'name';
+  }
+}
+
+exports.Tool = Tool;

--- a/app/templates/tools/includes/list.html
+++ b/app/templates/tools/includes/list.html
@@ -39,34 +39,28 @@
       {% endfor %}
     {% endif %}
 
-    {% set showRstudio = true %}
-    {% for tool in tools %}
-      {% if tool.app_label == 'rstudio' %}
-        {% set showRstudio = false %}
-      {% endif %}
-    {% endfor %}
-    {% if showRstudio %}
 
+    {% for deployable_tool in deployable_tools %}
     <tr>
-      <td>RStudio</td>
+      <td>{{ deployable_tool.name }}</td>
       <td>
-        {% if rstudio_is_deploying %}
-          Deploying
+        {% if is_deploying[deployable_tool.name] %}
+        Deploying
         {% else %}
-          Not deployed
+        Not deployed
         {% endif %}
       </td>
       <td class="align-right no-wrap">
-        {% if not rstudio_is_deploying %}
-          <form action="{{ url_for('tools.deploy', { name: 'rstudio' }) }}" method="post" class="inline-form clearfix">
-            <input type="submit" class="button button-secondary right" value="Deploy" />
-          </form>
+        {% if not is_deploying[deployable_tool.name] %}
+        <form action="{{ url_for('tools.deploy', { name: deployable_tool.name }) }}" method="post" class="inline-form clearfix">
+          <input type="submit" class="button button-secondary right" value="Deploy" />
+        </form>
         {% endif %}
       </td>
     </tr>
+    {% endfor %}
 
-    {% endif %}
-    </tbody>
+  </tbody>
   </table>
 
   <p>

--- a/app/tools/handlers.js
+++ b/app/tools/handlers.js
@@ -19,8 +19,8 @@ exports.restart = (req, res, next) => {
 
 exports.deploy = (req, res) => {
   Deployment.create({ tool_name: req.params.name });
-
-  req.session.rstudio_is_deploying = true;
+  req.session.is_deploying = req.session.is_deploying || {};
+  req.session.is_deploying[req.params.name] = true;
   req.session.flash_messages.push(`Deploying '${req.params.name}'...this may take up to 5 minutes`);
 
   res.redirect(`${url_for('base.home')}#${escape('Analytical tools')}`);

--- a/test/tools/test-restart.js
+++ b/test/tools/test-restart.js
@@ -45,7 +45,7 @@ describe('tools', () => {
       ])
         .then(([{ redirect_url, req }, deploy_request_done]) => {
           assert.equal(expected_redirect_url, redirect_url);
-          assert(req.session.rstudio_is_deploying);
+          assert(req.session.is_deploying[name]);
           assert(deploy_request_done);
         });
     });


### PR DESCRIPTION
The cpanel-api has been updated to allow deploying JupyterLab, this updates the
frontend to use the new functionality and refactors the tools template to
support multiple tools instead of hardcoding `rstudio`

https://trello.com/c/2i9vRoTQ/1338-stretch-jupyter-deployable-from-the-control-panel