### PR TITLE
Adds db migration to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,17 @@ services:
     environment:
       POSTGRES_USER: "controlpanel"
       POSTGRES_DB: "controlpanel"
+  migration:
+    image: "quay.io/mojanalytics/control-panel:master"
+    command: ["sh", "-c", "python3 wait_for_db && python3 manage.py migrate"]
+    environment:
+      DB_HOST: "db"
+      DB_NAME: "controlpanel"
+      DB_USER: "controlpanel"
+    links:
+      - db
+    depends_on:
+      - db
   redis:
     image: "redis:4.0.2-alpine"
     env_file:


### PR DESCRIPTION
## What

This is needed since this change to the control-panel (api):
https://github.com/ministryofjustice/analytics-platform-control-panel/pull/335
in which the migration is no longer done on container start-up.

Title the PR to complete the sentence: "Merging this PR will ..."

## How to review

```
docker-compose build
docker-compose up
docker-compose exec api python3 manage.py createsuperuser
```
Note it doesn't say this any more:
```
You have 17 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): auth, contenttypes, control_panel_api, sessions.
Run 'python manage.py migrate' to apply them.
```