### PR TITLE
Fix auth bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+HOST=0.0.0.0
+PORT=3000
+PROJECT=control-panel-frontend
+
+-include .env
+export
+
+.PHONY: collectstatic dependencies help run test wait_for_db
+
+## dependencies: Install dependencies
+dependencies:
+	@echo
+	@echo "> Fetching dependencies..."
+	@yarn install
+
+## collectstatic: Collect assets into static folder
+collectstatic:
+	@echo
+	@echo "> Collecting static assets..."
+	@yarn run collect-static
+
+## run: Run webapp
+run:
+	@echo
+	@echo "> Running webapp..."
+	@yarn run start
+
+## test: Run tests
+test:
+	@echo
+	@echo "> Running tests..."
+	@yarn run test
+
+## docker-image: Build docker image
+docker-image:
+	@echo
+	@echo "> Building docker image..."
+	@docker build -t ${PROJECT} .
+
+help: Makefile
+	@echo
+	@echo " Commands in "$(PROJECT)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' | sed -e 's/^/ /'
+	@echo

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -85,24 +85,31 @@ exports.error_test = (req, res, next) => {
 };
 
 
+function ensure_session_saved(req, next) {
+  if (req.session && req.session.save && typeof req.session.save === 'function') {
+    return req.session.save(next);
+  }
+  return next();
+}
+
+
 exports.auth_callback = [
   passport.authenticate('oidc', { failureRedirect: '/login?prompt=true' }),
   (req, res) => {
-    req.session.save(() => {
-      res.redirect(url_for('users.verify_email'));
-    });
+    ensure_session_saved(req, () => res.redirect(url_for('users.verify_email')));
   },
 ];
+
 
 exports.login = (req, res, next) => {
   if (req.isAuthenticated()) {
     if (/^http/.test(req.session.returnTo)) {
       throw new Error('URL must be relative');
     } else {
-      res.redirect(req.session.returnTo);
+      return ensure_session_saved(req, () => res.redirect(req.session.returnTo));
     }
   } else {
-    passport.authenticate('oidc', {
+    return passport.authenticate('oidc', {
       prompt: req.query.prompt || 'none',
     })(req, res, next);
   }

--- a/app/base/handlers.js
+++ b/app/base/handlers.js
@@ -88,7 +88,9 @@ exports.error_test = (req, res, next) => {
 exports.auth_callback = [
   passport.authenticate('oidc', { failureRedirect: '/login?prompt=true' }),
   (req, res) => {
-    res.redirect(url_for('users.verify_email'));
+    req.session.save(() => {
+      res.redirect(url_for('users.verify_email'));
+    });
   },
 ];
 

--- a/app/templates/includes/render_debug.html
+++ b/app/templates/includes/render_debug.html
@@ -1,5 +1,5 @@
-{% macro render_debug(debug_items, current_user_is_superuser, env_ENV) %}
-  {% if current_user_is_superuser or env_ENV == 'dev' %}
+{% macro render_debug(debug_items) %}
+  {% if current_user.is_superuser or env.ENV == 'dev' %}
   {% set default_items = [{name: 'current_user', value: current_user}, {name: 'req.session', value: req.session}] %}
   <div class="debug">
     <h2 class="heading-medium">Debug</h2>

--- a/app/templates/layouts/one-column.html
+++ b/app/templates/layouts/one-column.html
@@ -1,6 +1,6 @@
 {% extends "layouts/base.html" %}
 {% from "includes/breadcrumbs.html" import breadcrumbs_list %}
-{% from "includes/render_debug.html" import render_debug %}
+{% from "includes/render_debug.html" import render_debug with context %}
 
 {% block page_title %}
   {{ page_title }} | Analytical Platform Control Panel
@@ -25,7 +25,7 @@
   {% block main_column %}{% endblock %}
 
   {% block debug %}
-    {{ render_debug(debug_items, current_user.is_superuser, env.ENV) }}
+    {{ render_debug(debug_items) }}
   {% endblock %}
 
 </main>

--- a/test/base/test-login.js
+++ b/test/base/test-login.js
@@ -11,8 +11,13 @@ describe('OIDC callback', () => {
         id_token: 'test-token',
         username: 'test',
       };
+      const session = {
+        save: (next) => {
+          next();
+        },
+      };
 
-      return dispatch(handlers.auth_callback[1], { user })
+      return dispatch(handlers.auth_callback[1], { user, session })
         .then(({ redirect_url }) => {
           assert.equal(redirect_url, url_for('users.verify_email'));
         });


### PR DESCRIPTION
## What

* There was an error sometimes when logging in to the control panel:
  ```did not find expected authorization request details in session, req.session["oidc:alpha-analytics-moj.eu.auth0.com"] is undefined```
  This seems to be caused by a race-condition in ExpressJS, which can send the redirection headers to the client before the session has been stored. Then the client can load the redirection URL, which fails to retrieve the session because it hasn't been stored yet. This PR explicitly saves the session and only redirects when the save function returns.

* Fixed a minor issue where the `render_debug` template macro failed to display the default items (current user and session) because macros do not have access to the calling template context by default.

* Added a Makefile, because I forget which commands to run when switching between projects.