### PR TITLE
Fix deploying tools

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -71,7 +71,7 @@ config.aws = {
 };
 
 config.babel = {
-  presets: ['es2015'],
+  presets: ['@babel/preset-env'],
 };
 
 config.cluster = {

--- a/app/models/control_panel_api.js
+++ b/app/models/control_panel_api.js
@@ -46,7 +46,13 @@ class Model extends base.Model {
 
   static list() {
     return this.cpanel.get(this.endpoint, { page_size: 0 })
-      .then(result => new ModelSet(this.prototype.constructor, result.results));
+      .then((result) => {
+        let items = result;
+        if (result.results !== undefined) {
+          items = result.results;
+        }
+        return new ModelSet(this.prototype.constructor, items);
+      });
   }
 
   static create(data, options = {}) {
@@ -103,7 +109,7 @@ class Model extends base.Model {
 
 class App extends Model {
   static get endpoint() {
-    return 'apps';
+    return 'api/cpanel/v1/apps';
   }
 
   get apps3buckets() {
@@ -175,7 +181,7 @@ exports.App = App;
 
 class AppS3Bucket extends Model {
   static get endpoint() {
-    return 'apps3buckets';
+    return 'api/cpanel/v1/apps3buckets';
   }
 }
 
@@ -184,7 +190,7 @@ exports.AppS3Bucket = AppS3Bucket;
 
 class Bucket extends Model {
   static get endpoint() {
-    return 's3buckets';
+    return 'api/cpanel/v1/s3buckets';
   }
 
   get apps() {
@@ -228,7 +234,7 @@ exports.Bucket = Bucket;
 
 class User extends Model {
   static get endpoint() {
-    return 'users';
+    return 'api/cpanel/v1/users';
   }
 
   static get pk() {
@@ -277,7 +283,7 @@ exports.User = User;
 
 class UserS3Bucket extends Model {
   static get endpoint() {
-    return 'users3buckets';
+    return 'api/cpanel/v1/users3buckets';
   }
 }
 
@@ -286,7 +292,7 @@ exports.UserS3Bucket = UserS3Bucket;
 
 class UserApp extends Model {
   static get endpoint() {
-    return 'userapps';
+    return 'api/cpanel/v1/userapps';
   }
 }
 
@@ -294,7 +300,7 @@ exports.UserApp = UserApp;
 
 class Tool extends Model {
   static get endpoint() {
-    return 'tools';
+    return 'api/cpanel/v1/tools';
   }
 
   static get pk() {

--- a/app/models/kubernetes.js
+++ b/app/models/kubernetes.js
@@ -107,7 +107,7 @@ class Deployment extends Model {
   }
 
   static create(data) {
-    return this.cpanel.post(`tools/${data.tool_name}/deployments`, {});
+    return this.cpanel.post('/api/cpanel/v1/deployments/', { name: data.tool_name });
   }
 
   restart() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,49 +10,42 @@ services:
     links:
       - api
       - redis
-    env_file:
-      - .env
+    env_file: .env
     environment:
       AUTH0_CALLBACK_URL: "http://localhost:3000/callback"
       EXPRESS_HOST: "0.0.0.0"
       API_URL: "http://api:8000"
-      NODE_RESTART: "1"
       REDIS_HOST: "redis"
     volumes:
       - ./app:/home/cpanel/app
       - ./static:/home/cpanel/static
       - ./test:/home/cpanel/test
   api:
-    image: "quay.io/mojanalytics/control-panel:master"
+    image: "controlpanel:latest"
     ports:
       - "8000:8000"
     depends_on:
       - db
     links:
       - db
-    env_file:
-      - .env
+    env_file: .env
     environment:
-      - ALLOWED_HOSTS=*
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - DB_HOST=db
-      - DB_NAME=controlpanel
-      - DB_USER=controlpanel
-      - DEBUG=True
-      - DJANGO_SETTINGS_MODULE=control_panel_api.settings
-      - KUBECONFIG=/home/control-panel/.kube/config
-      - PYTHONUNBUFFERED=1
+      ALLOWED_HOSTS: "*"
+      DB_HOST: "db"
+      DB_NAME: "controlpanel"
+      DB_USER: "controlpanel"
+      DEBUG: "True"
+      PYTHONUNBUFFERED: 1
     volumes:
-      - $HOME/.kube:/home/control-panel/.kube
+      - ~/.kube/config:/home/controlpanel/.kube/config
   db:
     image: "circleci/postgres:9.6.2"
     environment:
       POSTGRES_USER: "controlpanel"
       POSTGRES_DB: "controlpanel"
   migration:
-    image: "quay.io/mojanalytics/control-panel:master"
-    command: ["sh", "-c", "python3 wait_for_db && python3 manage.py migrate"]
+    image: "controlpanel:latest"
+    command: sh -c "until pg_isready -h db; do sleep 2; done; ./manage.py migrate"
     environment:
       DB_HOST: "db"
       DB_NAME: "controlpanel"

--- a/test/api_clients/control_panel_api.js
+++ b/test/api_clients/control_panel_api.js
@@ -9,17 +9,17 @@ describe('Control Panel API Client', () => {
 
   it('rejects an invalid auth token', () => {
     const reason = { detail: 'Authentication credentials were not provided.' };
-    const expected = 'GET /apps/ was not permitted: Authentication credentials were not provided.';
+    const expected = 'GET /api/cpanel/v1/apps/ was not permitted: Authentication credentials were not provided.';
     const id_token = 'invalid token';
 
     const request = mock_api()
-      .get('/apps/')
+      .get('/api/cpanel/v1/apps/')
       .matchHeader('Authorization', `JWT ${id_token}`)
       .reply(403, reason);
 
     client.authenticate({ id_token });
 
-    return client.get('apps')
+    return client.get('api/cpanel/v1/apps')
       .then(() => {
         throw new Error('expected failure');
       })
@@ -47,13 +47,13 @@ describe('Control Panel API Client', () => {
     };
 
     mock_api()
-      .get('/apps/')
+      .get('/api/cpanel/v1/apps/')
       .matchHeader('Authorization', `JWT ${id_token}`)
       .reply(200, apps_response);
 
     client.authenticate({ id_token });
 
-    return client.get('apps')
+    return client.get('api/cpanel/v1/apps')
       .then((response) => { assert.deepEqual(response, apps_response); });
   });
 

--- a/test/apps/test-create.js
+++ b/test/apps/test-create.js
@@ -13,11 +13,11 @@ describe('apps/create', () => {
     const created_app = { id: 1 };
 
     mock_api()
-      .post('/apps/')
+      .post('/api/cpanel/v1/apps/')
       .reply(201, created_app);
 
     mock_api()
-      .post('/userapps/')
+      .post('/api/cpanel/v1/userapps/')
       .reply(201, {
         app: created_app.id,
         user: 'test-user',
@@ -44,7 +44,7 @@ describe('apps/create', () => {
     user.github_access_token = 'test-github-token';
 
     mock_api()
-      .post('/apps/')
+      .post('/api/cpanel/v1/apps/')
       .reply(400, errors);
 
     config.github.orgs = [
@@ -59,7 +59,7 @@ describe('apps/create', () => {
     });
 
     mock_api()
-      .get('/s3buckets/?page_size=0')
+      .get('/api/cpanel/v1/s3buckets/?page_size=0')
       .reply(200, []);
 
     return dispatch(handlers.create, { body: form_data })

--- a/test/apps/test-delete.js
+++ b/test/apps/test-delete.js
@@ -10,7 +10,7 @@ describe('apps/delete', () => {
     const user = { id_token: 'dummy-token' };
 
     const delete_app = mock_api()
-      .delete(`/apps/${params.id}/`)
+      .delete(`/api/cpanel/v1/apps/${params.id}/`)
       .reply(204);
 
     return dispatch(handlers.delete, { body, params, user })

--- a/test/apps/test-edit.js
+++ b/test/apps/test-edit.js
@@ -12,10 +12,10 @@ const ingresses = require('../fixtures/ingresses');
 
 describe('apps/edit', () => {
   it('loads app, buckets and users and shows a form', () => {
-    mock_api().get(`/apps/${app.id}/`).reply(200, app);
-    mock_api().get(`/apps/${app.id}/customers/`).reply(200, customers);
-    mock_api().get('/s3buckets/?page_size=0').reply(200, buckets);
-    mock_api().get('/users/?page_size=0').reply(200, users);
+    mock_api().get(`/api/cpanel/v1/apps/${app.id}/`).reply(200, app);
+    mock_api().get(`/api/cpanel/v1/apps/${app.id}/customers/`).reply(200, customers);
+    mock_api().get('/api/cpanel/v1/s3buckets/?page_size=0').reply(200, buckets);
+    mock_api().get('/api/cpanel/v1/users/?page_size=0').reply(200, users);
     mock_api().get('/k8s/apis/extensions/v1beta1/namespaces/apps-prod/ingresses?labelSelector=repo%3Dtest-app').reply(200, ingresses);
 
     const expected = {

--- a/test/apps3buckets/test-create.js
+++ b/test/apps3buckets/test-create.js
@@ -11,11 +11,11 @@ describe('apps3buckets/create', () => {
     const app_id = 1;
 
     mock_api()
-      .get(`/apps/${app_id}/`)
+      .get(`/api/cpanel/v1/apps/${app_id}/`)
       .reply(200, app);
 
     const post_apps3buckets = mock_api()
-      .post('/apps3buckets/', {
+      .post('/api/cpanel/v1/apps3buckets/', {
         app: app_id,
         s3bucket: bucket_id,
         access_level: 'readonly',

--- a/test/apps3buckets/test-delete.js
+++ b/test/apps3buckets/test-delete.js
@@ -9,7 +9,7 @@ describe('apps3buckets.delete', () => {
     const redirect_to = 'apps/123';
 
     const delete_apps3buckets = mock_api()
-      .delete(`/apps3buckets/${apps3bucket_id}/`)
+      .delete(`/api/cpanel/v1/apps3buckets/${apps3bucket_id}/`)
       .reply(204);
 
     const params = { id: apps3bucket_id };

--- a/test/apps3buckets/test-update.js
+++ b/test/apps3buckets/test-update.js
@@ -15,10 +15,10 @@ describe('apps3buckets.update', () => {
     const redirect_to = 'apps/123';
 
     const get_apps3bucket = mock_api()
-      .get(`/apps3buckets/${apps3bucket.id}/`)
+      .get(`/api/cpanel/v1/apps3buckets/${apps3bucket.id}/`)
       .reply(200, apps3bucket);
     const patch_apps3buckets = mock_api()
-      .patch(`/apps3buckets/${apps3bucket.id}/`, {
+      .patch(`/api/cpanel/v1/apps3buckets/${apps3bucket.id}/`, {
         id: apps3bucket.id,
         app_id: apps3bucket.app_id,
         s3bucket_id: apps3bucket.s3bucket_id,

--- a/test/buckets/test-create.js
+++ b/test/buckets/test-create.js
@@ -21,11 +21,11 @@ describe('buckets/create', () => {
     };
 
     mock_api()
-      .post('/s3buckets/')
+      .post('/api/cpanel/v1/s3buckets/')
       .reply(201, created_bucket);
 
     const get_user = mock_api()
-      .get(`/users/${escape(user.auth0_id)}/`)
+      .get(`/api/cpanel/v1/users/${escape(user.auth0_id)}/`)
       .reply(200, user);
 
     const req = {
@@ -61,7 +61,7 @@ describe('buckets/create', () => {
     process.env.ENV = 'test';
 
     mock_api()
-      .post('/s3buckets/')
+      .post('/api/cpanel/v1/s3buckets/')
       .reply(400, errors);
 
     return dispatch(handlers.create_bucket, { body: form_data })

--- a/test/buckets/test-details.js
+++ b/test/buckets/test-details.js
@@ -14,10 +14,10 @@ describe('buckets/details', () => {
     const params = { id: bucket.id };
     const user = { auth0_id: 'github|12345', id_token: 'dummy-token' };
 
-    mock_api().get(`/s3buckets/${bucket.id}/`).reply(200, bucket);
-    mock_api().get(`/s3buckets/${bucket.id}/access_logs/`).reply(200, access_logs);
-    mock_api().get('/apps/?page_size=0').reply(200, apps);
-    mock_api().get('/users/?page_size=0').reply(200, users);
+    mock_api().get(`/api/cpanel/v1/s3buckets/${bucket.id}/`).reply(200, bucket);
+    mock_api().get(`/api/cpanel/v1/s3buckets/${bucket.id}/access_logs/`).reply(200, access_logs);
+    mock_api().get('/api/cpanel/v1/apps/?page_size=0').reply(200, apps);
+    mock_api().get('/api/cpanel/v1/users/?page_size=0').reply(200, users);
 
     const expected = {
       apps: new ModelSet(App, apps.results).slice(1),

--- a/test/models/control_panel_api.js
+++ b/test/models/control_panel_api.js
@@ -10,12 +10,12 @@ describe('Control Panel API Model', () => {
   });
 
   it('has an endpoint', () => {
-    assert.equal(App.endpoint, 'apps');
+    assert.equal(App.endpoint, 'api/cpanel/v1/apps');
   });
 
   it('lists all instances', withAPI(() => {
     mock_api()
-      .get('/apps/')
+      .get('/api/cpanel/v1/apps/')
       .reply(200, apps_response);
 
     return App.list()
@@ -35,7 +35,7 @@ describe('Control Panel API Model', () => {
       name: app_data.name,
     };
     mock_api()
-      .post('/apps/')
+      .post('/api/cpanel/v1/apps/')
       .reply(201, expected);
 
     return App.create(app_data)
@@ -47,7 +47,7 @@ describe('Control Panel API Model', () => {
 
   it('Retrieves an instance by primary key', withAPI(() => {
     mock_api()
-      .get('/apps/1/')
+      .get('/api/cpanel/v1/apps/1/')
       .reply(200, apps_response.results[0]);
 
     return App.get(1)
@@ -58,7 +58,7 @@ describe('Control Panel API Model', () => {
 
   it('throws an exception if no instance found', withAPI(() => {
     mock_api()
-      .get('/apps/0/')
+      .get('/api/cpanel/v1/apps/0/')
       .reply(404, 'Not Found');
 
     return App.get(0)
@@ -72,7 +72,7 @@ describe('Control Panel API Model', () => {
 
   it('Deletes an instance by primary key', withAPI(() => {
     mock_api()
-      .delete('/apps/1/')
+      .delete('/api/cpanel/v1/apps/1/')
       .reply(204);
 
     return App.delete(1);
@@ -88,7 +88,7 @@ describe('Control Panel API Model', () => {
         name: app_data.name,
       };
       mock_api()
-        .post('/apps/')
+        .post('/api/cpanel/v1/apps/')
         .reply(201, expected);
 
       return new App(app_data).create()
@@ -107,7 +107,7 @@ describe('Control Panel API Model', () => {
         name: app_data.name,
       };
       mock_api()
-        .patch('/apps/1/')
+        .patch('/api/cpanel/v1/apps/1/')
         .reply(200, expected);
 
       const existing_app = new App({
@@ -125,7 +125,7 @@ describe('Control Panel API Model', () => {
       const existing_app = new App({ id: 1 });
 
       mock_api()
-        .delete('/apps/1/')
+        .delete('/api/cpanel/v1/apps/1/')
         .reply(204);
 
       return existing_app.delete();

--- a/test/tools/test-restart.js
+++ b/test/tools/test-restart.js
@@ -35,7 +35,7 @@ describe('tools', () => {
 
       const deploy_request = new Promise((resolve) => {
         mock_api()
-          .post(`/tools/${name}/deployments/`)
+          .post(`/api/cpanel/v1/deployments/`, {"name": name})
           .reply(201, () => { resolve(true); });
       });
 

--- a/test/users/test-delete.js
+++ b/test/users/test-delete.js
@@ -6,7 +6,9 @@ const handlers = require('../../app/users/handlers');
 describe('users', () => {
   describe('delete', () => {
     it('deletes user and redirects to list', () => {
-      const delete_request = mock_api().delete(`/users/${escape(user.auth0_id)}/`).reply(204);
+      const delete_request = mock_api()
+        .delete(`/api/cpanel/v1/users/${escape(user.auth0_id)}/`)
+        .reply(204);
 
       return dispatch(handlers.delete, { params: { id: user.auth0_id } })
         .then(({ redirect_url }) => {

--- a/test/users/test-details.js
+++ b/test/users/test-details.js
@@ -14,7 +14,7 @@ describe('users.details', () => {
     };
 
     mock_api()
-      .get(`/users/${encodeURIComponent(user.auth0_id)}/`)
+      .get(`/api/cpanel/v1/users/${encodeURIComponent(user.auth0_id)}/`)
       .reply(200, user);
 
     return dispatch(

--- a/test/users/test-update.js
+++ b/test/users/test-update.js
@@ -14,11 +14,11 @@ describe('users.update', () => {
     };
 
     mock_api()
-      .get(`/users/${encodeURIComponent(user.auth0_id)}/`)
+      .get(`/api/cpanel/v1/users/${encodeURIComponent(user.auth0_id)}/`)
       .reply(200, user);
 
     const request = mock_api()
-      .patch(`/users/${encodeURIComponent(user.auth0_id)}/`, expected.body)
+      .patch(`/api/cpanel/v1/users/${encodeURIComponent(user.auth0_id)}/`, expected.body)
       .reply(200);
 
     return dispatch(

--- a/test/users3buckets/test-create.js
+++ b/test/users3buckets/test-create.js
@@ -12,7 +12,7 @@ describe('users3buckets.create', () => {
     const data_access_level = 'readonly';
 
     const post_users3buckets = mock_api()
-      .post('/users3buckets/', {
+      .post('/api/cpanel/v1/users3buckets/', {
         user: user_id,
         s3bucket: bucket_id,
         access_level: data_access_level,
@@ -21,7 +21,7 @@ describe('users3buckets.create', () => {
       .reply(201);
 
     const get_user = mock_api()
-      .get(`/users/${escape(user_id)}/`)
+      .get(`/api/cpanel/v1/users/${escape(user_id)}/`)
       .reply(200, user);
 
     const req = {

--- a/test/users3buckets/test-delete.js
+++ b/test/users3buckets/test-delete.js
@@ -11,11 +11,11 @@ describe('users3buckets.delete', () => {
     const redirect_to = 'users/github|123';
 
     const delete_users3buckets = mock_api()
-      .delete(`/users3buckets/${users3bucket_id}/`)
+      .delete(`/api/cpanel/v1/users3buckets/${users3bucket_id}/`)
       .reply(204);
 
     const get_user = mock_api()
-      .get(`/users/${escape(user.auth0_id)}/`)
+      .get(`/api/cpanel/v1/users/${escape(user.auth0_id)}/`)
       .reply(200, user);
 
     const req = {

--- a/test/users3buckets/test-update.js
+++ b/test/users3buckets/test-update.js
@@ -18,11 +18,11 @@ describe('users3buckets.update', () => {
     };
 
     const patch_users3buckets = mock_api()
-      .patch(`/users3buckets/${users3bucket_id}/`, patchData)
+      .patch(`/api/cpanel/v1/users3buckets/${users3bucket_id}/`, patchData)
       .reply(201);
 
     const get_user = mock_api()
-      .get(`/users/${escape(user.auth0_id)}/`)
+      .get(`/api/cpanel/v1/users/${escape(user.auth0_id)}/`)
       .reply(200, user);
 
     const req = {


### PR DESCRIPTION
Fix listing and deploying tools
The API endpoints have all changed, and the significant changes for tools are
* The tools list JSON response does not have pagination metadata
* The deploy tool endpoint has changed from `/tools/<tool-name>/deploy` to `/api/cpanel/v1/deployments/` with the tool name in the POST body